### PR TITLE
Add spec for Monoid[Logger]

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -10,9 +10,10 @@ lazy val versions = new {
 lazy val scalaTest = "org.scalatest" %% "scalatest" % versions.scalaTest % Test
 
 lazy val cats = List(
-  "org.typelevel" %% "cats-core",
-  "org.typelevel" %% "cats-effect"
-).map(_ % versions.cats)
+  (version: String) => "org.typelevel" %% "cats-core" % version,
+  (version: String) => "org.typelevel" %% "cats-laws" % version % Test,
+  (version: String) => "org.typelevel" %% "cats-effect" % version
+).map(_.apply(versions.cats))
 
 lazy val catsMtl = "org.typelevel" %% "cats-mtl-core" % versions.catsMtl
 

--- a/core/src/test/scala/io/odin/EqInstances.scala
+++ b/core/src/test/scala/io/odin/EqInstances.scala
@@ -1,0 +1,64 @@
+package io.odin
+
+import cats.Eq
+import cats.effect.IO
+import org.scalacheck.Arbitrary
+
+import scala.annotation.tailrec
+
+trait EqInstances {
+
+  @tailrec
+  final def retrySample[T](implicit arb: Arbitrary[T]): T = arb.arbitrary.sample match {
+    case Some(v) => v
+    case _       => retrySample[T]
+  }
+
+  implicit def loggerEq[F[_]](
+      implicit arbitraryString: Arbitrary[String],
+      arbitraryCtx: Arbitrary[Map[String, String]],
+      arbitraryThrowable: Arbitrary[Throwable],
+      eqF: Eq[F[Unit]]
+  ): Eq[Logger[F]] =
+    (x: Logger[F], y: Logger[F]) => {
+      val msg = retrySample[String]
+      val ctx = retrySample[Map[String, String]]
+      val throwable = retrySample[Throwable]
+      eqF.eqv(x.trace(msg), y.trace(msg)) &&
+      eqF.eqv(x.trace(msg, throwable), y.trace(msg, throwable)) &&
+      eqF.eqv(x.trace(msg, ctx), y.trace(msg, ctx)) &&
+      eqF.eqv(x.trace(msg, ctx, throwable), y.trace(msg, ctx, throwable)) &&
+      eqF.eqv(x.debug(msg), y.debug(msg)) &&
+      eqF.eqv(x.debug(msg, throwable), y.debug(msg, throwable)) &&
+      eqF.eqv(x.debug(msg, ctx), y.debug(msg, ctx)) &&
+      eqF.eqv(x.debug(msg, ctx, throwable), y.debug(msg, ctx, throwable)) &&
+      eqF.eqv(x.info(msg), y.info(msg)) &&
+      eqF.eqv(x.info(msg, throwable), y.info(msg, throwable)) &&
+      eqF.eqv(x.info(msg, ctx), y.info(msg, ctx)) &&
+      eqF.eqv(x.info(msg, ctx, throwable), y.info(msg, ctx, throwable)) &&
+      eqF.eqv(x.warn(msg), y.warn(msg)) &&
+      eqF.eqv(x.warn(msg, throwable), y.warn(msg, throwable)) &&
+      eqF.eqv(x.warn(msg, ctx), y.warn(msg, ctx)) &&
+      eqF.eqv(x.warn(msg, ctx, throwable), y.warn(msg, ctx, throwable)) &&
+      eqF.eqv(x.error(msg), y.error(msg)) &&
+      eqF.eqv(x.error(msg, throwable), y.error(msg, throwable)) &&
+      eqF.eqv(x.error(msg, ctx), y.error(msg, ctx)) &&
+      eqF.eqv(x.error(msg, ctx, throwable), y.error(msg, ctx, throwable))
+    }
+
+  implicit def eqIO[A](implicit eqA: Eq[A]): Eq[IO[A]] = Eq.instance { (ioA, ioB) =>
+    eqA.eqv(ioA.unsafeRunSync(), ioB.unsafeRunSync())
+  }
+
+  implicit val loggerMessageEq: Eq[LoggerMessage] = Eq.instance { (lm1, lm2) =>
+    val LoggerMessage(lvl1, msg1, context1, exception1, position1, threadName1, timestamp1) = lm1
+    val LoggerMessage(lvl2, msg2, context2, exception2, position2, threadName2, timestamp2) = lm2
+    lvl1 == lvl2 &&
+      msg1() == msg2() &&
+      context1 == context2 &&
+      exception1 == exception2 &&
+      position1 == position2 &&
+      threadName1 == threadName2 &&
+      timestamp1 == timestamp2
+  }
+}

--- a/core/src/test/scala/io/odin/OdinSpec.scala
+++ b/core/src/test/scala/io/odin/OdinSpec.scala
@@ -3,11 +3,19 @@ package io.odin
 import io.odin.meta.Position
 import org.scalacheck.{Arbitrary, Gen}
 import org.scalatest.{FlatSpec, Matchers}
-import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
+import org.scalatestplus.scalacheck.{Checkers, ScalaCheckDrivenPropertyChecks}
+import org.typelevel.discipline.Laws
 
-trait OdinSpec extends FlatSpec with Matchers with ScalaCheckDrivenPropertyChecks {
+trait OdinSpec extends FlatSpec with Matchers with Checkers with ScalaCheckDrivenPropertyChecks with EqInstances {
 
-  val lineSeparator = System.lineSeparator()
+  def checkAll(name: String, ruleSet: Laws#RuleSet): Unit = {
+    for ((id, prop) <- ruleSet.all.properties)
+      it should (name + "." + id) in {
+        check(prop)
+      }
+  }
+
+  val lineSeparator: String = System.lineSeparator()
 
   val nonEmptyStringGen: Gen[String] = Gen.nonEmptyListOf(Gen.alphaNumChar).map(_.mkString)
 

--- a/core/src/test/scala/io/odin/loggers/LoggerMonoidSpec.scala
+++ b/core/src/test/scala/io/odin/loggers/LoggerMonoidSpec.scala
@@ -1,0 +1,47 @@
+package io.odin.loggers
+
+import java.util.UUID
+
+import cats.data.WriterT
+import cats.effect.{Clock, IO}
+import cats.instances.list._
+import cats.instances.tuple._
+import cats.instances.unit._
+import cats.instances.uuid._
+import cats.kernel.laws.discipline.MonoidTests
+import cats.syntax.all._
+import io.odin.{Logger, LoggerMessage, OdinSpec}
+import org.scalacheck.{Arbitrary, Gen}
+
+import scala.concurrent.duration.TimeUnit
+
+class LoggerMonoidSpec extends OdinSpec {
+
+  type F[A] = WriterT[IO, List[(UUID, LoggerMessage)], A]
+
+  checkAll("Logger", MonoidTests[Logger[F]].monoid)
+
+  it should "(logger1 |+| logger2).log <-> (logger1.log |+| logger2.log)" in {
+    forAll { (uuid1: UUID, uuid2: UUID, msg: LoggerMessage) =>
+      val logger1: Logger[F] = NamedLogger(uuid1)
+      val logger2: Logger[F] = NamedLogger(uuid2)
+      val a = (logger1 |+| logger2).log(msg)
+      val b = logger1.log(msg) |+| logger2.log(msg)
+      a.written.unsafeRunSync() shouldBe b.written.unsafeRunSync()
+    }
+  }
+
+  case class NamedLogger(loggerId: UUID) extends DefaultLogger[F] {
+    def log(msg: LoggerMessage): F[Unit] = WriterT.tell(List(loggerId -> msg))
+  }
+
+  implicit def clock: Clock[IO] = new Clock[IO] {
+    def realTime(unit: TimeUnit): IO[Long] = IO.pure(0)
+
+    def monotonic(unit: TimeUnit): IO[Long] = IO.pure(0)
+  }
+
+  implicit def arbitraryWriterLogger: Arbitrary[Logger[F]] = Arbitrary(
+    Gen.uuid.map(NamedLogger)
+  )
+}


### PR DESCRIPTION
- Check `Monoid[Logger]` implementation against cats-laws
- `(loggerA |+| loggerB).log(msg)` should be `loggerA.log(msg) |+| loggerB.log(msg)`
- Add equality instance `Eq[Logger]