### PR TITLE
Use ConcurrentQueue in AsyncLogger to have control over buffer

### DIFF
--- a/core/src/main/scala/io/odin/formatter/Formatter.scala
+++ b/core/src/main/scala/io/odin/formatter/Formatter.scala
@@ -21,7 +21,8 @@ object Formatter {
         val sw = new StringWriter()
         val pw = new PrintWriter(sw)
         t.printStackTrace(pw)
-        p"${msg.timestamp.t.F} [${msg.threadName}] ${msg.level.show} ${msg.position.enclosureName}:${msg.position.line} - ${msg.message()}${System.lineSeparator()}${sw.toString}"
+        p"${msg.timestamp.t.F} [${msg.threadName}] ${msg.level.show} ${msg.position.enclosureName}:${msg.position.line} - ${msg
+          .message()}${System.lineSeparator()}${sw.toString}"
       case None =>
         p"${msg.timestamp.t.F} [${msg.threadName}] ${msg.level.show} ${msg.position.enclosureName}:${msg.position.line} - ${msg.message()}"
     }

--- a/core/src/main/scala/io/odin/loggers/AsyncLogger.scala
+++ b/core/src/main/scala/io/odin/loggers/AsyncLogger.scala
@@ -1,20 +1,79 @@
 package io.odin.loggers
 
-import cats.effect.{Clock, Concurrent}
+import cats.effect.{Concurrent, ConcurrentEffect, ContextShift, Fiber, Timer}
+import cats.instances.list._
+import cats.syntax.all._
 import io.odin.{Logger, LoggerMessage}
+import monix.catnap.ConcurrentQueue
+import monix.execution.{BufferCapacity, ChannelType}
+
+import scala.concurrent.duration._
 
 /**
-  * AsyncLogger spawns non-cancellable `cats.effect.Fiber` with actual log action encapsulated there
+  * AsyncLogger spawns non-cancellable `cats.effect.Fiber` with actual log action encapsulated there.
+  *
+  * Use `AsyncLogger.withAsync` to instantiate it safely
   */
-//@TODO probably replace with monix queue instead to have control over the buffer
-case class AsyncLogger[F[_]: Clock](inner: Logger[F])(implicit F: Concurrent[F]) extends DefaultLogger[F] {
-  def log(msg: LoggerMessage): F[Unit] = F.void(F.start(inner.log(msg)))
+case class AsyncLogger[F[_]](queue: ConcurrentQueue[F, LoggerMessage])(inner: Logger[F])(
+    implicit F: Concurrent[F],
+    timer: Timer[F],
+    contextShift: ContextShift[F]
+) extends DefaultLogger[F] {
+  def log(msg: LoggerMessage): F[Unit] = {
+    queue.tryOffer(msg).void
+  }
+
+  /**
+    * Run internal loop of consuming events from the queue and push them down the chain
+    */
+  def runF: F[Fiber[F, Unit]] = {
+    def drain: F[Unit] =
+      queue
+        .drain(1, Int.MaxValue)
+        .map(msgs => msgs.toList.traverse(inner.log)) >> timer.sleep(1.millis) >> contextShift.shift >> drain
+    F.start(drain)
+  }
 }
 
 object AsyncLogger extends AsyncLoggerBuilder
 
 trait AsyncLoggerBuilder {
 
-  def withAsync[F[_]: Clock: Concurrent]: Logger[F] => Logger[F] = AsyncLogger.apply
+  /**
+    * Create async logger and start internal loop of sending events down the chain from the buffer once
+    * `F[_]` is started.
+    *
+    * @param maxBufferSize If `maxBufferSize` is set to some value and buffer size grows to that value,
+    *                      any new events will be dropped until there is a space in the buffer.
+    * @param inner logger that will receive messages from the buffer
+    */
+  def withAsync[F[_]: Timer: ContextShift](maxBufferSize: Option[Int] = None)(inner: Logger[F])(
+      implicit F: Concurrent[F]
+  ): F[Logger[F]] = {
+    val queueCapacity = maxBufferSize match {
+      case Some(value) =>
+        BufferCapacity.Bounded(value)
+      case None =>
+        BufferCapacity.Unbounded()
+    }
+    for {
+      queue <- ConcurrentQueue.withConfig[F, LoggerMessage](queueCapacity, ChannelType.MPSC)
+      logger = AsyncLogger(queue)(inner)
+      _ <- logger.runF
+    } yield {
+      logger
+    }
+  }
+
+  /**
+    * Create async logger and start internal loop of sending events down the chain from the buffer right away
+    * @param maxBufferSize If `maxBufferSize` is set to some value and buffer size grows to that value,
+    *                      any new events will be dropped until there is a space in the buffer.
+    */
+  def withAsyncUnsafe[F[_]: Timer: ContextShift](maxBufferSize: Option[Int])(
+      implicit F: ConcurrentEffect[F]
+  ): Logger[F] => Logger[F] = inner => {
+    F.toIO(withAsync(maxBufferSize)(inner)).unsafeRunSync()
+  }
 
 }

--- a/core/src/main/scala/io/odin/loggers/WriterTLogger.scala
+++ b/core/src/main/scala/io/odin/loggers/WriterTLogger.scala
@@ -1,0 +1,14 @@
+package io.odin.loggers
+
+import cats.Monad
+import cats.data.WriterT
+import cats.effect.Clock
+import cats.instances.list._
+import io.odin.LoggerMessage
+
+/**
+  * Pure logger that stores logs in `WriterT` log
+  */
+class WriterTLogger[F[_]: Clock: Monad] extends DefaultLogger[WriterT[F, List[LoggerMessage], *]] {
+  def log(msg: LoggerMessage): WriterT[F, List[LoggerMessage], Unit] = WriterT.tell(List(msg))
+}

--- a/core/src/main/scala/io/odin/writers/AsyncFileLogWriter.scala
+++ b/core/src/main/scala/io/odin/writers/AsyncFileLogWriter.scala
@@ -79,10 +79,7 @@ object AsyncFileLogWriter {
       fileName: String,
       timeWindow: FiniteDuration = 1.second
   )(implicit F: ConcurrentEffect[F]): LogWriter[F] = {
-    val writer =
-      new AsyncFileLogWriter[F](Files.newBufferedWriter(Paths.get(fileName), StandardOpenOption.APPEND), timeWindow)
-    F.toIO(writer.runFlush.map(_ => writer)).unsafeRunAsyncAndForget()
-    writer
+    F.toIO(apply[F](fileName, timeWindow)).unsafeRunSync()
   }
 
 }

--- a/core/src/test/scala/io/odin/loggers/AsyncLoggerSpec.scala
+++ b/core/src/test/scala/io/odin/loggers/AsyncLoggerSpec.scala
@@ -1,0 +1,51 @@
+package io.odin.loggers
+
+import cats.effect.concurrent.Ref
+import cats.instances.list._
+import cats.syntax.all._
+import io.odin.{Logger, LoggerMessage, OdinSpec}
+import monix.catnap.ConcurrentQueue
+import monix.eval.Task
+import monix.execution.schedulers.TestScheduler
+
+import scala.concurrent.duration._
+
+class AsyncLoggerSpec extends OdinSpec {
+
+  implicit private val scheduler: TestScheduler = TestScheduler()
+
+  case class RefLogger(ref: Ref[Task, List[LoggerMessage]]) extends DefaultLogger[Task] {
+    def log(msg: LoggerMessage): Task[Unit] = {
+      //have to run, otherwise ref never gets updated somehow
+      Task.pure(ref.update(_ :+ msg).runSyncUnsafe())
+    }
+  }
+
+  it should "push logs down the chain" in {
+    forAll { msgs: List[LoggerMessage] =>
+      (for {
+        ref <- Ref.of[Task, List[LoggerMessage]](List.empty)
+        logger <- AsyncLogger.withAsync[Task]()(RefLogger(ref))
+        _ <- msgs.traverse(logger.log)
+        _ = scheduler.tick(10.millis)
+        reported <- ref.get
+      } yield {
+        reported shouldBe msgs
+      }).runSyncUnsafe()
+    }
+  }
+
+  it should "push logs to the queue" in {
+    forAll { msgs: List[LoggerMessage] =>
+      (for {
+        queue <- ConcurrentQueue.unbounded[Task, LoggerMessage]()
+        logger = AsyncLogger(queue)(Logger.noop[Task])
+        _ <- msgs.traverse(logger.log)
+        reported <- queue.drain(0, Int.MaxValue)
+      } yield {
+        reported shouldBe msgs
+      }).runSyncUnsafe()
+    }
+  }
+
+}

--- a/core/src/test/scala/io/odin/loggers/WriterTLoggerSpec.scala
+++ b/core/src/test/scala/io/odin/loggers/WriterTLoggerSpec.scala
@@ -1,0 +1,26 @@
+package io.odin.loggers
+
+import cats.Id
+import cats.effect.Clock
+import cats.instances.list._
+import cats.syntax.all._
+import io.odin.{LoggerMessage, OdinSpec}
+
+import scala.concurrent.duration.TimeUnit
+
+class WriterTLoggerSpec extends OdinSpec {
+
+  implicit val clock: Clock[Id] = new Clock[Id] {
+    def realTime(unit: TimeUnit): Id[Long] = 0L
+    def monotonic(unit: TimeUnit): Id[Long] = 0L
+  }
+
+  it should "write all the logs into list" in {
+    val logger = new WriterTLogger[Id]()
+    forAll { msgs: List[LoggerMessage] =>
+      msgs.traverse(logger.log).written shouldBe msgs
+    }
+
+  }
+
+}


### PR DESCRIPTION
Instead of spawning an infinite amount of fibers, there is a way to roughly limit the maximum buffer size (in case of the need)