### PR TITLE
Add ExecutionContext parameter to all the writers

### DIFF
--- a/core/src/main/scala/io/odin/loggers/ConsoleLogger.scala
+++ b/core/src/main/scala/io/odin/loggers/ConsoleLogger.scala
@@ -1,7 +1,7 @@
 package io.odin.loggers
 
 import cats.Monad
-import cats.effect.{Clock, Sync}
+import cats.effect.{Clock, ContextShift, Sync}
 import cats.kernel.Comparison
 import cats.syntax.all._
 import io.odin.{Level, Logger, LoggerMessage}
@@ -22,7 +22,7 @@ object ConsoleLogger extends ConsoleLoggerBuilder
 
 trait ConsoleLoggerBuilder {
 
-  def consoleLogger[F[_]: Sync: Clock](formatter: Formatter): Logger[F] =
-    ConsoleLogger(formatter, StdOutLogWriter[F], StdErrLogWriter[F])
+  def consoleLogger[F[_]: Sync: Clock: ContextShift](formatter: Formatter): Logger[F] =
+    ConsoleLogger(formatter, StdOutLogWriter[F](), StdErrLogWriter[F]())
 
 }

--- a/core/src/main/scala/io/odin/writers/AsyncFileLogWriter.scala
+++ b/core/src/main/scala/io/odin/writers/AsyncFileLogWriter.scala
@@ -4,12 +4,14 @@ import java.io.BufferedWriter
 
 import scala.concurrent.duration._
 import java.nio.file.{Files, Paths, StandardOpenOption}
+import java.util.concurrent.Executors
 
 import cats.effect.{Concurrent, ConcurrentEffect, ContextShift, Fiber, Timer}
 import cats.syntax.all._
 import io.odin.LoggerMessage
 import io.odin.formatter.Formatter
 
+import scala.concurrent.ExecutionContext
 import scala.concurrent.duration.FiniteDuration
 
 /**
@@ -17,7 +19,11 @@ import scala.concurrent.duration.FiniteDuration
   *
   * Consider to use `AsyncFileLogWriter.apply` to start flushing loop properly
   */
-class AsyncFileLogWriter[F[_]](writer: BufferedWriter, timeWindow: FiniteDuration)(
+class AsyncFileLogWriter[F[_]](
+    writer: BufferedWriter,
+    timeWindow: FiniteDuration,
+    ec: ExecutionContext = unboundedExecutionContext
+)(
     implicit F: Concurrent[F],
     timer: Timer[F],
     contextShift: ContextShift[F]
@@ -31,8 +37,10 @@ class AsyncFileLogWriter[F[_]](writer: BufferedWriter, timeWindow: FiniteDuratio
   }
 
   def write(msg: LoggerMessage, formatter: Formatter): F[Unit] = {
-    F.delay {
-      writer.write(formatter.format(msg) + System.lineSeparator())
+    contextShift.evalOn(ec) {
+      F.delay {
+        writer.write(formatter.format(msg) + System.lineSeparator())
+      }
     }
   }
 
@@ -46,7 +54,7 @@ class AsyncFileLogWriter[F[_]](writer: BufferedWriter, timeWindow: FiniteDuratio
 
     def close: F[Unit] = F.delay(writer.close())
 
-    F.onCancel(F.start(recFlush).map { fiber =>
+    F.onCancel(F.start(contextShift.evalOn(ec)(recFlush)).map { fiber =>
       Fiber(fiber.join, close >> fiber.cancel)
     }) {
       close
@@ -62,11 +70,13 @@ object AsyncFileLogWriter {
     * BEWARE that cancellation invalidates the `BufferedWriter` as well, no `write` could be performed after that.
     * @param fileName name of log file to append to
     * @param timeWindow pause between flushing log events into file
+    * @param ec Execution Context that will be used to allocate threads during write/flush
     * @return [[LogWriter]] in the context of `F[_]` that will run internal async flush loop once it's started.
     */
   def apply[F[_]: ContextShift: Timer](
       fileName: String,
-      timeWindow: FiniteDuration = 1.second
+      timeWindow: FiniteDuration = 1.second,
+      ec: ExecutionContext = unboundedExecutionContext
   )(implicit F: Concurrent[F]): F[LogWriter[F]] =
     F.delay(new AsyncFileLogWriter[F](Files.newBufferedWriter(Paths.get(fileName)), timeWindow)).flatMap { writer =>
       writer.runFlush.map(_ => writer)
@@ -77,7 +87,8 @@ object AsyncFileLogWriter {
     */
   def unsafe[F[_]: ContextShift: Timer](
       fileName: String,
-      timeWindow: FiniteDuration = 1.second
+      timeWindow: FiniteDuration = 1.second,
+      ec: ExecutionContext = unboundedExecutionContext
   )(implicit F: ConcurrentEffect[F]): LogWriter[F] = {
     F.toIO(apply[F](fileName, timeWindow)).unsafeRunSync()
   }

--- a/core/src/main/scala/io/odin/writers/AsyncFileLogWriter.scala
+++ b/core/src/main/scala/io/odin/writers/AsyncFileLogWriter.scala
@@ -1,10 +1,7 @@
 package io.odin.writers
 
 import java.io.BufferedWriter
-
-import scala.concurrent.duration._
-import java.nio.file.{Files, Paths, StandardOpenOption}
-import java.util.concurrent.Executors
+import java.nio.file.{Files, Paths}
 
 import cats.effect.{Concurrent, ConcurrentEffect, ContextShift, Fiber, Timer}
 import cats.syntax.all._
@@ -12,7 +9,7 @@ import io.odin.LoggerMessage
 import io.odin.formatter.Formatter
 
 import scala.concurrent.ExecutionContext
-import scala.concurrent.duration.FiniteDuration
+import scala.concurrent.duration.{FiniteDuration, _}
 
 /**
   * Async file logger that flushes the buffer after each `timeWindow`
@@ -90,7 +87,7 @@ object AsyncFileLogWriter {
       timeWindow: FiniteDuration = 1.second,
       ec: ExecutionContext = unboundedExecutionContext
   )(implicit F: ConcurrentEffect[F]): LogWriter[F] = {
-    F.toIO(apply[F](fileName, timeWindow)).unsafeRunSync()
+    F.toIO(apply[F](fileName, timeWindow, ec)).unsafeRunSync()
   }
 
 }

--- a/core/src/main/scala/io/odin/writers/StdErrLogWriter.scala
+++ b/core/src/main/scala/io/odin/writers/StdErrLogWriter.scala
@@ -1,10 +1,13 @@
 package io.odin.writers
 
-import cats.effect.Sync
+import cats.effect.{ContextShift, Sync}
+
+import scala.concurrent.ExecutionContext
 
 object StdErrLogWriter {
 
   //@TODO revisit for Scala.js support later
-  def apply[F[_]: Sync]: LogWriter[F] = StdLogWriter.mk(scala.Console.err)
+  def apply[F[_]: Sync: ContextShift](ec: ExecutionContext = unboundedExecutionContext): LogWriter[F] =
+    StdLogWriter.mk(scala.Console.err, ec)
 
 }

--- a/core/src/main/scala/io/odin/writers/StdLogWriter.scala
+++ b/core/src/main/scala/io/odin/writers/StdLogWriter.scala
@@ -2,13 +2,27 @@ package io.odin.writers
 
 import java.io.PrintStream
 
-import cats.effect.Sync
+import cats.effect.{ContextShift, Sync}
 import io.odin.LoggerMessage
 import io.odin.formatter.Formatter
 
+import scala.concurrent.ExecutionContext
+
 object StdLogWriter {
 
-  def mk[F[_]](out: PrintStream)(implicit F: Sync[F]): LogWriter[F] =
-    (msg: LoggerMessage, formatter: Formatter) => F.delay(out.println(formatter.format(msg)))
+  /**
+    * Logger that writes formatted logs to the given `PrintStream` by allocating threads from
+    * provided `ExecutionContext`
+    * @param out stream to write information into
+    * @param ec thread pool that will be used for writing into stream
+    */
+  def mk[F[_]](
+      out: PrintStream,
+      ec: ExecutionContext = unboundedExecutionContext
+  )(implicit F: Sync[F], contextShift: ContextShift[F]): LogWriter[F] =
+    (msg: LoggerMessage, formatter: Formatter) =>
+      contextShift.evalOn(ec) {
+        F.delay(out.println(formatter.format(msg)))
+      }
 
 }

--- a/core/src/main/scala/io/odin/writers/StdOutLogWriter.scala
+++ b/core/src/main/scala/io/odin/writers/StdOutLogWriter.scala
@@ -1,10 +1,13 @@
 package io.odin.writers
 
-import cats.effect.Sync
+import cats.effect.{ContextShift, Sync}
+
+import scala.concurrent.ExecutionContext
 
 object StdOutLogWriter {
 
   //@TODO revisit for Scala.js support later
-  def apply[F[_]: Sync]: LogWriter[F] = StdLogWriter.mk(scala.Console.out)
+  def apply[F[_]: Sync: ContextShift](ec: ExecutionContext = unboundedExecutionContext): LogWriter[F] =
+    StdLogWriter.mk(scala.Console.out, ec)
 
 }

--- a/core/src/main/scala/io/odin/writers/package.scala
+++ b/core/src/main/scala/io/odin/writers/package.scala
@@ -1,0 +1,15 @@
+package io.odin
+
+import java.util.concurrent.Executors
+
+import scala.concurrent.ExecutionContext
+
+package object writers {
+
+  /**
+    * Unbounded EC is useful for I/O operations
+    */
+  def unboundedExecutionContext: ExecutionContext =
+    ExecutionContext.fromExecutor(Executors.newCachedThreadPool())
+
+}

--- a/core/src/test/scala/io/odin/writers/StdLogWriterSpec.scala
+++ b/core/src/test/scala/io/odin/writers/StdLogWriterSpec.scala
@@ -2,11 +2,13 @@ package io.odin.writers
 
 import java.io.{ByteArrayOutputStream, PrintStream}
 
-import cats.effect.IO
+import cats.effect.{ContextShift, IO}
 import io.odin.formatter.Formatter
 import io.odin.{LoggerMessage, OdinSpec}
 
 class StdLogWriterSpec extends OdinSpec {
+
+  implicit val cs: ContextShift[IO] = IO.contextShift(scala.concurrent.ExecutionContext.global)
 
   it should "write formatted log to PrintStream" in {
     forAll { loggerMessage: LoggerMessage =>


### PR DESCRIPTION
To offload actual write/flush from the main thread pool to unbounded cached one (by default)