### PR TITLE
Add more syntax & reshuffle methods. Drop Formatter.simple

### DIFF
--- a/benchmarks/src/main/scala/io/odin/Benchmarks.scala
+++ b/benchmarks/src/main/scala/io/odin/Benchmarks.scala
@@ -3,6 +3,8 @@ package io.odin
 import java.nio.file.{Files, Paths}
 import java.util.UUID
 import java.util.concurrent.TimeUnit
+import io.odin._
+import io.odin.syntax._
 
 import cats.effect.{ContextShift, IO, Timer}
 import io.odin.formatter.Formatter
@@ -47,7 +49,7 @@ class DefaultLoggerBenchmarks extends OdinBenchmarks {
 class FileLoggerBenchmarks extends OdinBenchmarks {
 
   val fileName: String = Files.createTempFile(UUID.randomUUID().toString, "").toAbsolutePath.toString
-  val fileLogger: Logger[IO] = FileLogger.unsafe[IO](fileName, Formatter.default)
+  val fileLogger: Logger[IO] = fileLoggerUnsafe[IO](fileName, Formatter.default)
 
   @Benchmark
   @OperationsPerInvocation(1000)
@@ -75,9 +77,7 @@ class FileLoggerBenchmarks extends OdinBenchmarks {
 class AsyncLoggerBenchmark extends OdinBenchmarks {
 
   val fileName: String = Files.createTempFile(UUID.randomUUID().toString, "").toAbsolutePath.toString
-  val asyncLogger: Logger[IO] = AsyncLogger.withAsyncUnsafe[IO](None).apply {
-    FileLogger.unsafe[IO](fileName, Formatter.default)
-  }
+  val asyncLogger: Logger[IO] = fileLoggerUnsafe[IO](fileName, Formatter.default).withAsyncUnsafe()
 
   @Benchmark
   @OperationsPerInvocation(1000)
@@ -105,11 +105,8 @@ class RouterLoggerBenchmarks extends OdinBenchmarks {
 
   val fileName: String = Files.createTempFile(UUID.randomUUID().toString, "").toAbsolutePath.toString
 
-  val routerLogger: Logger[IO] = {
-    RouterLogger.withMinimalLevel[IO](io.odin.Level.Info) {
-      FileLogger.unsafe[IO](fileName, Formatter.default)
-    }
-  }
+  val routerLogger: Logger[IO] =
+    fileLoggerUnsafe[IO](fileName, Formatter.default).withMinimalLevel(io.odin.Level.Info)
 
   @Benchmark
   @OperationsPerInvocation(1000)

--- a/core/src/main/scala/io/odin/formatter/Formatter.scala
+++ b/core/src/main/scala/io/odin/formatter/Formatter.scala
@@ -14,7 +14,6 @@ trait Formatter {
 
 object Formatter {
 
-  val simple: Formatter = (msg: LoggerMessage) => p"${msg.toString}. Message: ${msg.message()}"
   val default: Formatter = (msg: LoggerMessage) => {
     msg.exception match {
       case Some(t) =>

--- a/core/src/main/scala/io/odin/loggers/ConsoleLogger.scala
+++ b/core/src/main/scala/io/odin/loggers/ConsoleLogger.scala
@@ -18,11 +18,3 @@ case class ConsoleLogger[F[_]: Clock: Monad](formatter: Formatter, out: LogWrite
     }
 }
 
-object ConsoleLogger extends ConsoleLoggerBuilder
-
-trait ConsoleLoggerBuilder {
-
-  def consoleLogger[F[_]: Sync: Clock: ContextShift](formatter: Formatter): Logger[F] =
-    ConsoleLogger(formatter, StdOutLogWriter[F], StdErrLogWriter[F])
-
-}

--- a/core/src/main/scala/io/odin/loggers/ConstContextLogger.scala
+++ b/core/src/main/scala/io/odin/loggers/ConstContextLogger.scala
@@ -8,11 +8,9 @@ case class ConstContextLogger[F[_]: Clock: Monad](ctx: Map[String, String])(inne
   def log(msg: LoggerMessage): F[Unit] = inner.log(msg.copy(context = msg.context ++ ctx))
 }
 
-object ConstContextLogger extends ConstContextLoggerBuilder
+object ConstContextLogger {
 
-trait ConstContextLoggerBuilder {
-
-  def withConstContext[F[_]: Clock: Monad](ctx: Map[String, String])(inner: Logger[F]): Logger[F] =
+  def withConstContext[F[_]: Clock: Monad](ctx: Map[String, String], inner: Logger[F]): Logger[F] =
     ConstContextLogger(ctx)(inner)
 
 }

--- a/core/src/main/scala/io/odin/loggers/ContextualLogger.scala
+++ b/core/src/main/scala/io/odin/loggers/ContextualLogger.scala
@@ -17,10 +17,8 @@ case class ContextualLogger[F[_]: Clock: Monad](inner: Logger[F])(implicit withC
     }
 }
 
-object ContextualLogger extends ContextualLoggerBuilder
-
-trait ContextualLoggerBuilder {
-  def withContextualLogger[F[_]: Clock: Monad: WithContext]: Logger[F] => Logger[F] = ContextualLogger.apply
+object ContextualLogger {
+  def withContext[F[_]: Clock: Monad: WithContext](inner: Logger[F]): Logger[F] = ContextualLogger(inner)
 }
 
 /**

--- a/core/src/main/scala/io/odin/loggers/FileLogger.scala
+++ b/core/src/main/scala/io/odin/loggers/FileLogger.scala
@@ -16,33 +16,3 @@ case class FileLogger[F[_]: Clock: Monad](logWriter: LogWriter[F], formatter: Fo
   def log(msg: LoggerMessage): F[Unit] = logWriter.write(msg, formatter)
 }
 
-object FileLogger {
-
-  /**
-    * Safely start async file logger. Cancellation of `F[_]` will be propagated down the chain to safely close the buffer.
-    * BEWARE that cancellation invalidates the writer as well, no logging could be performed after that safely.
-    * @param fileName name of log file to append to
-    * @param formatter formatter to use
-    * @param timeWindow pause between flushing log events into file
-    * @return [[Logger]] in the context of `F[_]` that will asynchronously write to given file with rate of `timeWindow`
-    *        once started
-    */
-  def apply[F[_]: Concurrent: Timer: ContextShift](
-      fileName: String,
-      formatter: Formatter,
-      timeWindow: FiniteDuration = 1.second
-  ): F[Logger[F]] = {
-    AsyncFileLogWriter[F](fileName, timeWindow).map { writer =>
-      new FileLogger(writer, formatter)
-    }
-  }
-
-  def unsafe[F[_]: ConcurrentEffect: Timer: ContextShift](
-      fileName: String,
-      formatter: Formatter,
-      timeWindow: FiniteDuration = 1.second
-  ): Logger[F] = {
-    FileLogger(AsyncFileLogWriter.unsafe[F](fileName, timeWindow), formatter)
-  }
-
-}

--- a/core/src/main/scala/io/odin/loggers/RouterLogger.scala
+++ b/core/src/main/scala/io/odin/loggers/RouterLogger.scala
@@ -14,9 +14,7 @@ case class RouterLogger[F[_]: Clock: Monad](router: PartialFunction[LoggerMessag
   def log(msg: LoggerMessage): F[Unit] = withFallback(msg).log(msg)
 }
 
-object RouterLogger extends RouterLoggerBuilder
-
-trait RouterLoggerBuilder {
+object RouterLogger {
 
   /**
     * Route logs to specific logger based on the fully qualified package name.
@@ -68,7 +66,7 @@ trait RouterLoggerBuilder {
   /**
     * Route logs only if the level is greater or equal to the defined level. Otherwise logs are nooped.
     */
-  def withMinimalLevel[F[_]: Clock: Monad](level: Level)(inner: Logger[F]): Logger[F] =
+  def withMinimalLevel[F[_]: Clock: Monad](level: Level, inner: Logger[F]): Logger[F] =
     RouterLogger {
       case msg if msg.level >= level => inner
     }

--- a/core/src/main/scala/io/odin/package.scala
+++ b/core/src/main/scala/io/odin/package.scala
@@ -1,16 +1,50 @@
 package io
 
-import io.odin.loggers.{
-  AsyncLoggerBuilder,
-  ConsoleLoggerBuilder,
-  ConstContextLoggerBuilder,
-  ContextualLoggerBuilder,
-  RouterLoggerBuilder
-}
+import cats.effect.{Clock, Concurrent, ConcurrentEffect, ContextShift, Sync, Timer}
+import io.odin.formatter.Formatter
+import io.odin.loggers.{ConsoleLogger, FileLogger}
+import io.odin.writers.{AsyncFileLogWriter, StdErrLogWriter, StdOutLogWriter}
+import scala.concurrent.duration._
+import cats.syntax.all._
 
-package object odin
-    extends AsyncLoggerBuilder
-    with ConsoleLoggerBuilder
-    with ConstContextLoggerBuilder
-    with ContextualLoggerBuilder
-    with RouterLoggerBuilder
+import scala.concurrent.duration.FiniteDuration
+
+package object odin {
+
+  /**
+    * Basic console logger that prints to STDOUT & STDERR
+    * @param formatter formatter to use for log messages
+    */
+  def consoleLogger[F[_]: Sync: Clock: ContextShift](formatter: Formatter = Formatter.default): Logger[F] =
+    ConsoleLogger(formatter, StdOutLogWriter[F], StdErrLogWriter[F])
+
+  /**
+    * Safely start async file logger. Cancellation of `F[_]` will be propagated down the chain to safely close the buffer.
+    * BEWARE that cancellation invalidates the writer as well, no logging could be performed after that safely.
+    * @param fileName name of log file to append to
+    * @param formatter formatter to use
+    * @param timeWindow pause between flushing log events into file
+    * @return [[Logger]] in the context of `F[_]` that will asynchronously write to given file with rate of `timeWindow`
+    *        once started
+    */
+  def fileLogger[F[_]: Concurrent: Timer: ContextShift](
+      fileName: String,
+      formatter: Formatter = Formatter.default,
+      timeWindow: FiniteDuration = 1.second
+  ): F[Logger[F]] = {
+    AsyncFileLogWriter[F](fileName, timeWindow).map { writer =>
+      new FileLogger(writer, formatter)
+    }
+  }
+
+  /**
+    * Unsafe version of [[fileLogger]] that runs uncancellable flush loop in the background during instantiation.
+    */
+  def fileLoggerUnsafe[F[_]: ConcurrentEffect: Timer: ContextShift](
+      fileName: String,
+      formatter: Formatter = Formatter.default,
+      timeWindow: FiniteDuration = 1.second
+  ): Logger[F] = {
+    FileLogger(AsyncFileLogWriter.unsafe[F](fileName, timeWindow), formatter)
+  }
+}

--- a/core/src/main/scala/io/odin/syntax/package.scala
+++ b/core/src/main/scala/io/odin/syntax/package.scala
@@ -1,22 +1,31 @@
 package io.odin
 
 import cats.Monad
-import cats.effect.Clock
-import io.odin.loggers.{ConstContextLogger, ContextualLogger, RouterLogger, WithContext}
+import cats.effect.{Clock, Concurrent, ConcurrentEffect, ContextShift, Timer}
+import io.odin.loggers.{AsyncLogger, ConstContextLogger, ContextualLogger, RouterLogger, WithContext}
 
 package object syntax {
 
   implicit class LoggerSyntax[F[_]](logger: Logger[F]) {
 
     def withMinimalLevel(level: Level)(implicit clock: Clock[F], monad: Monad[F]): Logger[F] =
-      RouterLogger.withMinimalLevel(level)(logger)
+      RouterLogger.withMinimalLevel(level, logger)
 
     def withConstContext(ctx: Map[String, String])(implicit clock: Clock[F], monad: Monad[F]): Logger[F] =
-      ConstContextLogger.withConstContext(ctx)(logger)
+      ConstContextLogger.withConstContext(ctx, logger)
 
-    def withContextualLogger(implicit clock: Clock[F], monad: Monad[F], withContext: WithContext[F]): Logger[F] =
-      ContextualLogger.withContextualLogger.apply(logger)
+    def withContext(implicit clock: Clock[F], monad: Monad[F], withContext: WithContext[F]): Logger[F] =
+      ContextualLogger.withContext(logger)
 
+    def withAsync(
+        maxBufferSize: Option[Int] = None
+    )(implicit timer: Timer[F], F: Concurrent[F], contextShift: ContextShift[F]): F[Logger[F]] =
+      AsyncLogger.withAsync(maxBufferSize, logger)
+
+    def withAsyncUnsafe(
+        maxBufferSize: Option[Int] = None
+    )(implicit timer: Timer[F], F: ConcurrentEffect[F], contextShift: ContextShift[F]): Logger[F] =
+      AsyncLogger.withAsyncUnsafe(maxBufferSize, logger)
   }
 
 }

--- a/core/src/test/scala/io/odin/OdinSpec.scala
+++ b/core/src/test/scala/io/odin/OdinSpec.scala
@@ -54,7 +54,7 @@ trait OdinSpec extends FlatSpec with Matchers with Checkers with ScalaCheckDrive
   }
   implicit val loggerMessageArbitrary: Arbitrary[LoggerMessage] = Arbitrary(loggerMessageGen)
 
-  val formatterGen: Gen[Formatter] = Gen.const(Formatter.simple)
+  val formatterGen: Gen[Formatter] = Gen.const(Formatter.default)
   implicit val formatterArbitrary: Arbitrary[Formatter] = Arbitrary(formatterGen)
 
 }

--- a/core/src/test/scala/io/odin/loggers/AsyncLoggerSpec.scala
+++ b/core/src/test/scala/io/odin/loggers/AsyncLoggerSpec.scala
@@ -7,6 +7,7 @@ import io.odin.{Logger, LoggerMessage, OdinSpec}
 import monix.catnap.ConcurrentQueue
 import monix.eval.Task
 import monix.execution.schedulers.TestScheduler
+import io.odin.syntax._
 
 import scala.concurrent.duration._
 
@@ -25,7 +26,7 @@ class AsyncLoggerSpec extends OdinSpec {
     forAll { msgs: List[LoggerMessage] =>
       (for {
         ref <- Ref.of[Task, List[LoggerMessage]](List.empty)
-        logger <- AsyncLogger.withAsync[Task]()(RefLogger(ref))
+        logger <- RefLogger(ref).withAsync()
         _ <- msgs.traverse(logger.log)
         _ = scheduler.tick(10.millis)
         reported <- ref.get

--- a/core/src/test/scala/io/odin/loggers/ConsoleLoggerSpec.scala
+++ b/core/src/test/scala/io/odin/loggers/ConsoleLoggerSpec.scala
@@ -24,7 +24,7 @@ class ConsoleLoggerSpec extends OdinSpec {
     def write(msg: LoggerMessage, formatter: Formatter): F[Unit] = WriterT.tell(List((err, msg)))
   }
 
-  private val consoleLogger = ConsoleLogger[F](Formatter.simple, stdOutWriter, stdErrWriter)
+  private val consoleLogger = ConsoleLogger[F](Formatter.default, stdOutWriter, stdErrWriter)
 
   it should "route all messages with level <= INFO to stdout" in {
     forAll { loggerMessage: LoggerMessage =>

--- a/core/src/test/scala/io/odin/loggers/ContextualLoggerSpec.scala
+++ b/core/src/test/scala/io/odin/loggers/ContextualLoggerSpec.scala
@@ -1,9 +1,11 @@
 package io.odin.loggers
 
+import cats.arrow.FunctionK
 import cats.data.{ReaderT, WriterT}
 import cats.effect.{IO, Timer}
 import cats.instances.list._
 import cats.mtl.instances.all._
+import io.odin.syntax._
 import io.odin.{LoggerMessage, OdinSpec}
 
 class ContextualLoggerSpec extends OdinSpec {
@@ -14,13 +16,11 @@ class ContextualLoggerSpec extends OdinSpec {
   implicit val hasContext: HasContext[Map[String, String]] = (env: Map[String, String]) => env
   implicit val timer: Timer[IO] = IO.timer(scala.concurrent.ExecutionContext.global)
 
-  private val logger = new DefaultLogger[F] {
-    def log(msg: LoggerMessage): F[Unit] = ReaderT.liftF(WriterT.tell(List(msg)))
-  }
+  private val logger = new WriterTLogger[IO].mapK(λ[FunctionK[W, F]](ReaderT.liftF(_)))
 
   it should "pick up context from F[_]" in {
     forAll { (loggerMessage: LoggerMessage, ctx: Map[String, String]) =>
-      val log = ContextualLogger.withContextualLogger[F].apply(logger)
+      val log = logger.withContext
       val List(written) = log.log(loggerMessage).apply(ctx).written.unsafeRunSync()
       written.context shouldBe loggerMessage.context ++ ctx
     }

--- a/core/src/test/scala/io/odin/loggers/RouterLoggerSpec.scala
+++ b/core/src/test/scala/io/odin/loggers/RouterLoggerSpec.scala
@@ -5,6 +5,7 @@ import cats.effect.{IO, Timer}
 import cats.instances.list._
 import cats.syntax.all._
 import io.odin.{Level, Logger, LoggerMessage, OdinSpec}
+import io.odin.syntax._
 
 class RouterLoggerSpec extends OdinSpec {
 
@@ -66,12 +67,10 @@ class RouterLoggerSpec extends OdinSpec {
 
     type FF[A] = WriterT[IO, List[LoggerMessage], A]
 
-    val logger = new DefaultLogger[FF] {
-      def log(msg: LoggerMessage): FF[Unit] = WriterT.tell(List(msg))
-    }
+    val logger = new WriterTLogger[IO]
 
     forAll { (level: Level, msg: LoggerMessage) =>
-      val log = RouterLogger.withMinimalLevel[FF](level)(logger)
+      val log = logger.withMinimalLevel(level)
       val written = log.log(msg).written.unsafeRunSync()
       if (msg.level >= level) {
         written shouldBe List(msg)

--- a/core/src/test/scala/io/odin/writers/AsyncFileLogWriterSpec.scala
+++ b/core/src/test/scala/io/odin/writers/AsyncFileLogWriterSpec.scala
@@ -36,11 +36,11 @@ class AsyncFileLogWriterSpec extends OdinSpec {
               .liftF {
                 for {
                   writer <- AsyncFileLogWriter[IO](fileName, 5.millis)
-                  _ <- loggerMessage.traverse(writer.write(_, Formatter.simple))
+                  _ <- loggerMessage.traverse(writer.write(_, Formatter.default))
                   _ <- timer.sleep(100.millis)
                 } yield {
                   new String(Files.readAllBytes(Paths.get(fileName))) shouldBe loggerMessage
-                    .map(Formatter.simple.format)
+                    .map(Formatter.default.format)
                     .mkString(lineSeparator) + (if (loggerMessage.isEmpty) "" else lineSeparator)
                 }
               }
@@ -60,7 +60,7 @@ class AsyncFileLogWriterSpec extends OdinSpec {
             Resource
               .liftF {
                 for {
-                  _ <- writer.write(loggerMessage, Formatter.simple)
+                  _ <- writer.write(loggerMessage, Formatter.default)
                   _ <- timer.sleep(200.millis)
                 } yield {
                   new String(Files.readAllBytes(Paths.get(fileName))) shouldBe empty

--- a/core/src/test/scala/io/odin/writers/SyncFileLogWriterSpec.scala
+++ b/core/src/test/scala/io/odin/writers/SyncFileLogWriterSpec.scala
@@ -29,10 +29,10 @@ class SyncFileLogWriterSpec extends OdinSpec with BeforeAndAfter {
           val fileName = path.toString
           val writer = SyncFileLogWriter[Task](fileName)
           Resource
-            .liftF(loggerMessage.traverse(writer.write(_, Formatter.simple)))
+            .liftF(loggerMessage.traverse(writer.write(_, Formatter.default)))
             .map { _ =>
               new String(Files.readAllBytes(Paths.get(fileName))) shouldBe loggerMessage
-                .map(Formatter.simple.format)
+                .map(Formatter.default.format)
                 .mkString(lineSeparator) + (if (loggerMessage.isEmpty) "" else lineSeparator)
             }
         }


### PR DESCRIPTION
Cover syntax with tests, drop "builders" in favor of chainable syntax. Remove `Formatter.simple`