### PR TITLE
Add formatter benchmarks

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -64,7 +64,7 @@ lazy val `odin-core` = (project in file("core"))
 lazy val benchmarks = (project in file("benchmarks"))
   .settings(sharedSettings)
   .enablePlugins(JmhPlugin)
-  .dependsOn(`odin-core`)
+  .dependsOn(`odin-core`, `odin-json`)
 
 lazy val `odin-json` = (project in file("json"))
   .settings(sharedSettings)


### PR DESCRIPTION
Results from my local

```
[info] Benchmark                             Mode  Cnt      Score      Error Units
[info] FormatterBenchmarks.defaultFormatter  avgt   25   3363,869 ±  265,856 ns/op
[info] FormatterBenchmarks.jsonFormatter     avgt   25  16907,061 ± 1140,653 ns/op
```