### PR TITLE
Add log for lists for the sake of performance with AsyncLogger

### DIFF
--- a/benchmarks/src/main/scala/io/odin/Benchmarks.scala
+++ b/benchmarks/src/main/scala/io/odin/Benchmarks.scala
@@ -90,7 +90,8 @@ class FileLoggerBenchmarks extends OdinBenchmarks {
 @State(Scope.Benchmark)
 class AsyncLoggerBenchmark extends OdinBenchmarks {
   val fileName: String = Files.createTempFile(UUID.randomUUID().toString, "").toAbsolutePath.toString
-  val (asyncLogger: Logger[IO], cancelToken: IO[Unit]) = fileLogger[IO](fileName).withAsync().allocated.unsafeRunSync()
+  val (asyncLogger: Logger[IO], cancelToken: IO[Unit]) =
+    fileLogger[IO](fileName).withAsync(maxBufferSize = Some(1000000)).allocated.unsafeRunSync()
 
   @Benchmark
   @OperationsPerInvocation(1000)

--- a/core/src/main/scala/io/odin/loggers/ConstContextLogger.scala
+++ b/core/src/main/scala/io/odin/loggers/ConstContextLogger.scala
@@ -6,6 +6,8 @@ import io.odin.{Logger, LoggerMessage}
 
 case class ConstContextLogger[F[_]: Clock: Monad](ctx: Map[String, String])(inner: Logger[F]) extends DefaultLogger {
   def log(msg: LoggerMessage): F[Unit] = inner.log(msg.copy(context = msg.context ++ ctx))
+  override def log(msgs: List[LoggerMessage]): F[Unit] =
+    inner.log(msgs.map(msg => msg.copy(context = msg.context ++ ctx)))
 }
 
 object ConstContextLogger {

--- a/core/src/main/scala/io/odin/loggers/ContextualLogger.scala
+++ b/core/src/main/scala/io/odin/loggers/ContextualLogger.scala
@@ -15,6 +15,11 @@ case class ContextualLogger[F[_]: Clock: Monad](inner: Logger[F])(implicit withC
     withContext.context.flatMap { ctx =>
       inner.log(msg.copy(context = msg.context ++ ctx))
     }
+
+  override def log(msgs: List[LoggerMessage]): F[Unit] =
+    withContext.context.flatMap { ctx =>
+      inner.log(msgs.map(msg => msg.copy(context = msg.context ++ ctx)))
+    }
 }
 
 object ContextualLogger {

--- a/core/src/main/scala/io/odin/loggers/DefaultLogger.scala
+++ b/core/src/main/scala/io/odin/loggers/DefaultLogger.scala
@@ -4,6 +4,7 @@ import java.util.concurrent.TimeUnit
 
 import cats.Monad
 import cats.effect.Clock
+import cats.instances.all._
 import cats.syntax.all._
 import io.odin.meta.{Position, Render}
 import io.odin.{Level, Logger, LoggerMessage}
@@ -33,6 +34,9 @@ abstract class DefaultLogger[F[_]](implicit clock: Clock[F], F: Monad[F]) extend
     } yield {
       ()
     }
+
+  def log(msgs: List[LoggerMessage]): F[Unit] =
+    msgs.traverse(msg => log(msg)).void
 
   def trace[M](msg: => M)(implicit render: Render[M], position: Position): F[Unit] =
     log(Level.Trace, msg)

--- a/core/src/main/scala/io/odin/loggers/FileLogger.scala
+++ b/core/src/main/scala/io/odin/loggers/FileLogger.scala
@@ -3,6 +3,9 @@ package io.odin.loggers
 import java.io.BufferedWriter
 import java.nio.file.{Files, Paths}
 
+import cats.syntax.all._
+import cats.effect.syntax.all._
+import cats.instances.list._
 import cats.effect.{Clock, Resource, Sync}
 import io.odin.formatter.Formatter
 import io.odin.{Logger, LoggerMessage}
@@ -12,23 +15,26 @@ import io.odin.{Logger, LoggerMessage}
   */
 case class FileLogger[F[_]: Clock](buffer: BufferedWriter, formatter: Formatter)(implicit F: Sync[F])
     extends DefaultLogger[F] {
-  def log(msg: LoggerMessage): F[Unit] = write(msg, formatter)
+  def log(msg: LoggerMessage): F[Unit] =
+    write(msg, formatter).guarantee(flush)
 
-  def write(msg: LoggerMessage, formatter: Formatter): F[Unit] = {
-    F.guarantee {
-      F.delay {
-        buffer.write(formatter.format(msg) + System.lineSeparator())
-      }
-    }(flush)
-  }
+  override def log(msgs: List[LoggerMessage]): F[Unit] =
+    msgs.traverse(write(_, formatter)).void.guarantee(flush)
 
-  def flush: F[Unit] = F.handleErrorWith(F.delay(buffer.flush()))(_ => F.unit)
+  private def write(msg: LoggerMessage, formatter: Formatter): F[Unit] =
+    F.delay {
+      buffer.write(formatter.format(msg) + System.lineSeparator())
+    }
+
+  private def flush: F[Unit] = F.delay(buffer.flush()).handleErrorWith(_ => F.unit)
 }
 
 object FileLogger {
   def apply[F[_]: Clock](fileName: String, formatter: Formatter)(implicit F: Sync[F]): Resource[F, Logger[F]] = {
     def mkBuffer: F[BufferedWriter] = F.delay(Files.newBufferedWriter(Paths.get(fileName)))
-    def closeBuffer(buffer: BufferedWriter): F[Unit] = F.delay(buffer.close())
+    def closeBuffer(buffer: BufferedWriter): F[Unit] = F.delay {
+      buffer.close()
+    }
 
     Resource.make(mkBuffer)(closeBuffer).map { buffer =>
       FileLogger(buffer, formatter)

--- a/core/src/main/scala/io/odin/loggers/WriterTLogger.scala
+++ b/core/src/main/scala/io/odin/loggers/WriterTLogger.scala
@@ -11,4 +11,6 @@ import io.odin.LoggerMessage
   */
 class WriterTLogger[F[_]: Clock: Monad] extends DefaultLogger[WriterT[F, List[LoggerMessage], *]] {
   def log(msg: LoggerMessage): WriterT[F, List[LoggerMessage], Unit] = WriterT.tell(List(msg))
+
+  override def log(msgs: List[LoggerMessage]): WriterT[F, List[LoggerMessage], Unit] = WriterT.tell(msgs)
 }

--- a/core/src/test/scala/io/odin/loggers/ConstContextLoggerSpec.scala
+++ b/core/src/test/scala/io/odin/loggers/ConstContextLoggerSpec.scala
@@ -19,4 +19,12 @@ class ConstContextLoggerSpec extends OdinSpec {
       written.context shouldBe loggerMessage.context ++ ctx
     }
   }
+
+  it should "add constant context to the records" in {
+    forAll { (messages: List[LoggerMessage], ctx: Map[String, String]) =>
+      val logger = new WriterTLogger[IO].withConstContext(ctx)
+      val written = logger.log(messages).written.unsafeRunSync()
+      written.map(_.context) shouldBe messages.map(_.context ++ ctx)
+    }
+  }
 }

--- a/core/src/test/scala/io/odin/loggers/ContextualLoggerSpec.scala
+++ b/core/src/test/scala/io/odin/loggers/ContextualLoggerSpec.scala
@@ -24,4 +24,12 @@ class ContextualLoggerSpec extends OdinSpec {
       written.context shouldBe loggerMessage.context ++ ctx
     }
   }
+
+  it should "embed context in all messages" in {
+    forAll { (msgs: List[LoggerMessage], ctx: Map[String, String]) =>
+      val log = logger.withContext
+      val written = log.log(msgs).apply(ctx).written.unsafeRunSync()
+      written.map(_.context) shouldBe msgs.map(_.context ++ ctx)
+    }
+  }
 }

--- a/core/src/test/scala/io/odin/loggers/LoggerMonoidSpec.scala
+++ b/core/src/test/scala/io/odin/loggers/LoggerMonoidSpec.scala
@@ -30,6 +30,16 @@ class LoggerMonoidSpec extends OdinSpec {
     }
   }
 
+  it should "(logger1 |+| logger2).log(list) <-> (logger1.log |+| logger2.log(list))" in {
+    forAll { (uuid1: UUID, uuid2: UUID, msg: List[LoggerMessage]) =>
+      val logger1: Logger[F] = NamedLogger(uuid1)
+      val logger2: Logger[F] = NamedLogger(uuid2)
+      val a = (logger1 |+| logger2).log(msg)
+      val b = logger1.log(msg) |+| logger2.log(msg)
+      a.written.unsafeRunSync() shouldBe b.written.unsafeRunSync()
+    }
+  }
+
   case class NamedLogger(loggerId: UUID) extends DefaultLogger[F] {
     def log(msg: LoggerMessage): F[Unit] = WriterT.tell(List(loggerId -> msg))
   }

--- a/core/src/test/scala/io/odin/loggers/WriterTLoggerSpec.scala
+++ b/core/src/test/scala/io/odin/loggers/WriterTLoggerSpec.scala
@@ -2,8 +2,6 @@ package io.odin.loggers
 
 import cats.Id
 import cats.effect.Clock
-import cats.instances.list._
-import cats.syntax.all._
 import io.odin.{LoggerMessage, OdinSpec}
 
 import scala.concurrent.duration.TimeUnit
@@ -14,10 +12,17 @@ class WriterTLoggerSpec extends OdinSpec {
     def monotonic(unit: TimeUnit): Id[Long] = 0L
   }
 
+  it should "write log into list" in {
+    val logger = new WriterTLogger[Id]()
+    forAll { msg: LoggerMessage =>
+      logger.log(msg).written shouldBe List(msg)
+    }
+  }
+
   it should "write all the logs into list" in {
     val logger = new WriterTLogger[Id]()
     forAll { msgs: List[LoggerMessage] =>
-      msgs.traverse(logger.log).written shouldBe msgs
+      logger.log(msgs).written shouldBe msgs
     }
   }
 }


### PR DESCRIPTION
Add method `Logger.log(msgs: List[LoggerMessage]): F[Unit]` that allows effective use of `FileLogger` and `AsyncLogger` to batch log operations whenever the need arises.