### PR TITLE
Improve routing loggers

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,6 +6,7 @@ lazy val versions = new {
   val monix = "3.1.0"
   val scalaCheck = "1.14.2"
   val catsRetry = "0.3.2"
+  val catsScalacheck = "0.2.0"
 }
 
 lazy val scalaVersions = List("2.13.1", "2.12.10")
@@ -31,6 +32,8 @@ lazy val monix = "io.monix" %% "monix" % versions.monix % Test
 lazy val perfolation = "com.outr" %% "perfolation" % "1.1.5"
 
 lazy val circeCore = "io.circe" %% "circe-core" % "0.12.3"
+
+lazy val catsScalacheck = "io.chrisdavenport" %% "cats-scalacheck" % versions.catsScalacheck % Test
 
 lazy val catsRetry = List(
   "com.github.cb372" %% "cats-retry-core",
@@ -78,7 +81,7 @@ lazy val sharedSettings = Seq(
 lazy val `odin-core` = (project in file("core"))
   .settings(sharedSettings)
   .settings(
-    libraryDependencies ++= monix :: catsMtl :: sourcecode :: monixCatnap :: perfolation :: catsRetry ::: cats
+    libraryDependencies ++= catsScalacheck :: monix :: catsMtl :: sourcecode :: monixCatnap :: perfolation :: catsRetry ::: cats
   )
 
 lazy val benchmarks = (project in file("benchmarks"))

--- a/core/src/main/scala/io/odin/Level.scala
+++ b/core/src/main/scala/io/odin/Level.scala
@@ -6,30 +6,36 @@ import cats.{Order, Show}
 /**
   * Message log level
   */
-sealed abstract class Level(val value: Int)
+sealed trait Level
 
 object Level {
-  case object Trace extends Level(0) {
+  case object Trace extends Level {
     override val toString: String = "TRACE"
   }
 
-  case object Debug extends Level(1) {
+  case object Debug extends Level {
     override val toString: String = "DEBUG"
   }
 
-  case object Info extends Level(2) {
+  case object Info extends Level {
     override val toString: String = "INFO"
   }
 
-  case object Warn extends Level(3) {
+  case object Warn extends Level {
     override val toString: String = "WARN"
   }
 
-  case object Error extends Level(4) {
+  case object Error extends Level {
     override val toString: String = "ERROR"
   }
 
   implicit val show: Show[Level] = Show.fromToString[Level]
 
-  implicit val order: Order[Level] = Order.by[Level, Int](_.value)
+  implicit val order: Order[Level] = Order.by[Level, Int] {
+    case Error => 4
+    case Warn  => 3
+    case Info  => 2
+    case Debug => 1
+    case Trace => 0
+  }
 }

--- a/core/src/main/scala/io/odin/loggers/AsyncLogger.scala
+++ b/core/src/main/scala/io/odin/loggers/AsyncLogger.scala
@@ -51,9 +51,10 @@ object AsyncLogger {
     * Create async logger and start internal loop of sending events down the chain from the buffer once
     * `Resource` is used.
     *
+    * @param inner logger that will receive messages from the buffer
+    * @param timeWindow pause between buffer flushing
     * @param maxBufferSize If `maxBufferSize` is set to some value and buffer size grows to that value,
     *                      any new events might be dropped until there is a space in the buffer.
-    * @param inner logger that will receive messages from the buffer
     */
   def withAsync[F[_]: Timer: ContextShift](
       inner: Logger[F],

--- a/core/src/main/scala/io/odin/loggers/ContextualLogger.scala
+++ b/core/src/main/scala/io/odin/loggers/ContextualLogger.scala
@@ -7,7 +7,11 @@ import cats.syntax.all._
 import io.odin.{Logger, LoggerMessage}
 
 /**
-  * Logger that extracts context from environment of `F[_]` with the help of [[WithContext]] type class
+  * Logger that extracts context from environment of `F[_]` with the help of [[WithContext]] type class.
+  *
+  * One of the examples of `F[_]` that has a context is `Reader` (also known as `Kleisli`) that is abstraction over
+  * function `A => M[B]`. If there is a way to extract context `Map[String, String]` from the `A` (see [[HasContext]]),
+  * then it's possible to add this context to the log.
   */
 case class ContextualLogger[F[_]: Timer: Monad](inner: Logger[F])(implicit withContext: WithContext[F])
     extends DefaultLogger[F] {

--- a/core/src/main/scala/io/odin/loggers/RouterLogger.scala
+++ b/core/src/main/scala/io/odin/loggers/RouterLogger.scala
@@ -2,70 +2,103 @@ package io.odin.loggers
 
 import cats.Monad
 import cats.effect.Timer
+import cats.instances.list._
+import cats.instances.map._
 import cats.syntax.all._
 import io.odin.{Level, Logger, LoggerMessage}
 
-case class RouterLogger[F[_]: Timer: Monad](router: PartialFunction[LoggerMessage, Logger[F]])
-    extends DefaultLogger[F] {
-  private val noop = Logger.noop
-  private val withFallback: PartialFunction[LoggerMessage, Logger[F]] = router.orElse { case _ => noop }
-
-  def log(msg: LoggerMessage): F[Unit] = withFallback(msg).log(msg)
-}
+import scala.annotation.tailrec
 
 object RouterLogger {
   /**
     * Route logs to specific logger based on the fully qualified package name.
     * Beware of O(n) complexity due to the partial matching done during the logging
     */
-  def packageRoutingLogger[F[_]: Timer: Monad](router: (String, Logger[F])*): Logger[F] = {
-    val noop = Logger.noop
-    RouterLogger {
-      case msg =>
-        router
-          .collectFirst {
-            case (packageName, logger) if msg.position.packageName.startsWith(packageName) =>
-              logger
-          }
-          .getOrElse(noop)
-    }
+  def packageRoutingLogger[F[_]: Timer: Monad](router: (String, Logger[F])*): DefaultBuilder[F] = {
+    new DefaultBuilder[F](new EnclosureRouting(_, router.toList))
   }
 
   /**
     * Route logs to specific logger based on `Class[_]` instance.
     * Beware of O(n) complexity due to the partial matching done during the logging
     */
-  def classRoutingLogger[F[_]: Timer: Monad](router: (Class[_], Logger[F])*): Logger[F] = {
-    val noop = Logger.noop
-    val classNameRouter = router.map {
-      case (cls, logger) => (cls.getName, logger)
-    }
-    RouterLogger {
-      case msg =>
-        classNameRouter
-          .collectFirst {
-            case (className, logger) if msg.position.enclosureName.startsWith(className) =>
-              logger
-          }
-          .getOrElse(noop)
-    }
-  }
+  def classRoutingLogger[F[_]: Timer: Monad](
+      router: (Class[_], Logger[F])*
+  ): DefaultBuilder[F] =
+    new DefaultBuilder[F](new EnclosureRouting(_, router.toList.map {
+      case (cls, logger) => cls.getName -> logger
+    }))
 
   /**
     * Route logs based on their level
     *
-    * Complexity should be roughly constant and based on Map hashing/collisions
+    * Complexity should be roughly constant
     */
-  def levelRoutingLogger[F[_]: Timer: Monad](router: Map[Level, Logger[F]]): Logger[F] =
-    RouterLogger {
-      case msg if router.contains(msg.level) => router(msg.level)
-    }
+  def levelRoutingLogger[F[_]: Timer: Monad](router: Map[Level, Logger[F]]): DefaultBuilder[F] =
+    new DefaultBuilder[F]({ default: Logger[F] =>
+      new DefaultLogger[F]() {
+        def log(msg: LoggerMessage): F[Unit] = router.getOrElse(msg.level, default).log(msg)
+
+        override def log(msgs: List[LoggerMessage]): F[Unit] = {
+          msgs.groupBy(_.level).toList.traverse_ {
+            case (level, msgs) => router.getOrElse(level, default).log(msgs)
+          }
+        }
+      }
+    })
 
   /**
     * Route logs only if the level is greater or equal to the defined level. Otherwise logs are nooped.
     */
-  def withMinimalLevel[F[_]: Timer: Monad](level: Level, inner: Logger[F]): Logger[F] =
-    RouterLogger {
-      case msg if msg.level >= level => inner
+  def withMinimalLevel[F[_]: Timer](level: Level, inner: Logger[F])(implicit F: Monad[F]): Logger[F] =
+    new DefaultLogger[F]() {
+      def log(msg: LoggerMessage): F[Unit] = if (msg.level >= level) inner.log(msg) else F.unit
+      override def log(msgs: List[LoggerMessage]): F[Unit] = {
+        msgs.filter(_.level >= level) match {
+          case Nil  => F.unit
+          case list => inner.log(list)
+        }
+      }
     }
+
+  private class EnclosureRouting[F[_]: Monad: Timer](fallback: Logger[F], router: List[(String, Logger[F])])
+      extends DefaultLogger {
+    private val indexedRouter = router.mapWithIndex {
+      case ((packageName, logger), idx) => (packageName, (idx, logger))
+    }
+
+    def log(msg: LoggerMessage): F[Unit] = recLog(indexedRouter, msg)
+
+    override def log(msgs: List[LoggerMessage]): F[Unit] = {
+      msgs
+        .map { msg =>
+          indexedRouter
+            .collectFirst {
+              case (key, indexedLogger) if msg.position.enclosureName.startsWith(key) => indexedLogger
+            }
+            .getOrElse(-1 -> fallback) -> List(msg)
+        }
+        .foldLeft(Map.empty[(Int, Logger[F]), List[LoggerMessage]]) {
+          case (map, kv) => map |+| Map(kv)
+        }
+        .toList
+        .traverse_ {
+          case ((_, logger), ms) => logger.log(ms)
+        }
+    }
+
+    @tailrec
+    private def recLog(router: List[(String, (Int, Logger[F]))], msg: LoggerMessage): F[Unit] = router match {
+      case Nil                                                                   => fallback.log(msg)
+      case (key, (_, logger)) :: _ if msg.position.enclosureName.startsWith(key) => logger.log(msg)
+      case _ :: tail                                                             => recLog(tail, msg)
+    }
+  }
+
+  class DefaultBuilder[F[_]: Timer: Monad](withDefault: Logger[F] => Logger[F]) {
+    def withNoopFallback: Logger[F] =
+      withDefault(Logger.noop[F])
+    def withFallback(fallback: Logger[F]): Logger[F] =
+      withDefault(fallback)
+  }
 }

--- a/core/src/main/scala/io/odin/package.scala
+++ b/core/src/main/scala/io/odin/package.scala
@@ -3,6 +3,9 @@ package io
 import cats.effect.{Concurrent, ContextShift, Resource, Sync, Timer}
 import io.odin.formatter.Formatter
 import io.odin.loggers.{ConsoleLogger, FileLogger}
+import io.odin.syntax._
+
+import scala.concurrent.duration._
 
 package object odin {
   /**
@@ -17,10 +20,25 @@ package object odin {
     * @param fileName name of log file to append to
     * @param formatter formatter to use
     */
-  def fileLogger[F[_]: Concurrent: Timer: ContextShift](
+  def fileLogger[F[_]: Sync: Timer](
       fileName: String,
       formatter: Formatter = Formatter.default
   ): Resource[F, Logger[F]] = {
     FileLogger(fileName, formatter)
   }
+
+  /**
+    * Create async logger with safe log file allocation and intermediate async buffer
+    * @param fileName name of log file to append to
+    * @param formatter formatter to use
+    * @param timeWindow pause between async buffer flushing
+    * @param maxBufferSize maximum buffer size
+    */
+  def asyncFileLogger[F[_]: Concurrent: Timer: ContextShift](
+      fileName: String,
+      formatter: Formatter = Formatter.default,
+      timeWindow: FiniteDuration = 1.second,
+      maxBufferSize: Option[Int] = None
+  ): Resource[F, Logger[F]] =
+    fileLogger[F](fileName, formatter).withAsync(timeWindow, maxBufferSize)
 }

--- a/core/src/main/scala/io/odin/syntax/package.scala
+++ b/core/src/main/scala/io/odin/syntax/package.scala
@@ -8,21 +8,46 @@ import scala.concurrent.duration._
 
 package object syntax {
   implicit class LoggerSyntax[F[_]](logger: Logger[F]) {
+    /**
+      * Create logger that filters logs with level less than required
+      * @param level minimal log level filter
+      */
     def withMinimalLevel(level: Level)(implicit clock: Timer[F], monad: Monad[F]): Logger[F] =
       RouterLogger.withMinimalLevel(level, logger)
 
+    /**
+      * Create logger that adds constant context to each log record
+      * @param ctx constant context
+      */
     def withConstContext(ctx: Map[String, String])(implicit clock: Timer[F], monad: Monad[F]): Logger[F] =
       ConstContextLogger.withConstContext(ctx, logger)
 
+    /**
+      * Create contextual logger that is capable of picking up context from inside of `F[_]`.
+      * See [[ContextualLogger]] for more info
+      */
     def withContext(implicit clock: Timer[F], monad: Monad[F], withContext: WithContext[F]): Logger[F] =
       ContextualLogger.withContext(logger)
 
+    /**
+      * Create async logger that buffers the messages up to the limit (if any) and flushes it down the chain each `timeWindow`
+      * @param timeWindow pause between async buffer flushing
+      * @param maxBufferSize max logs buffer size
+      * @return Logger suspended in `Resource`. Once this `Resource` started, internal flush loop is initialized. Once
+      *         resource is released, flushing is also stopped.
+      */
     def withAsync(
         timeWindow: FiniteDuration = 1.millis,
         maxBufferSize: Option[Int] = None
     )(implicit timer: Timer[F], F: Concurrent[F], contextShift: ContextShift[F]): Resource[F, Logger[F]] =
       AsyncLogger.withAsync(logger, timeWindow, maxBufferSize)
 
+    /**
+      * Create and unsafely run async logger that buffers the messages up to the limit (if any) and
+      * flushes it down the chain each `timeWindow`
+      * @param timeWindow  pause between async buffer flushing
+      * @param maxBufferSize max logs buffer size
+      */
     def withAsyncUnsafe(
         timeWindow: FiniteDuration = 1.millis,
         maxBufferSize: Option[Int] = None
@@ -34,18 +59,37 @@ package object syntax {
     * Syntax for loggers suspended in `Resource` (i.e. `AsyncLogger` or `FileLogger`)
     */
   implicit class ResourceLoggerSyntax[F[_]](resource: Resource[F, Logger[F]]) {
+    /**
+      * Create async logger that buffers the messages up to the limit (if any) and flushes it down the chain each `timeWindow`
+      * @param timeWindow pause between async buffer flushing
+      * @param maxBufferSize max logs buffer size
+      * @return Logger suspended in `Resource`. Once this `Resource` started, internal flush loop is initialized. Once
+      *         resource is released, flushing is also stopped.
+      */
     def withAsync(
         timeWindow: FiniteDuration = 1.millis,
         maxBufferSize: Option[Int] = None
     )(implicit timer: Timer[F], F: Concurrent[F], contextShift: ContextShift[F]): Resource[F, Logger[F]] =
       resource.flatMap(AsyncLogger.withAsync(_, timeWindow, maxBufferSize))
 
+    /**
+      * Create logger that filters logs with level less than required
+      * @param level minimal log level filter
+      */
     def withMinimalLevel(level: Level)(implicit clock: Timer[F], monad: Monad[F]): Resource[F, Logger[F]] =
       resource.map(RouterLogger.withMinimalLevel(level, _))
 
+    /**
+      * Create logger that adds constant context to each log record
+      * @param ctx constant context
+      */
     def withConstContext(ctx: Map[String, String])(implicit clock: Timer[F], monad: Monad[F]): Resource[F, Logger[F]] =
       resource.map(ConstContextLogger.withConstContext(ctx, _))
 
+    /**
+      * Create contextual logger that is capable of picking up context from inside of `F[_]`.
+      * See [[ContextualLogger]] for more info
+      */
     def withContext(implicit clock: Timer[F], monad: Monad[F], withContext: WithContext[F]): Resource[F, Logger[F]] =
       resource.map(ContextualLogger.withContext[F])
   }

--- a/core/src/test/scala/io/odin/OdinSpec.scala
+++ b/core/src/test/scala/io/odin/OdinSpec.scala
@@ -24,7 +24,7 @@ trait OdinSpec extends FlatSpec with Matchers with Checkers with ScalaCheckDrive
 
   val positionGen: Gen[Position] = for {
     fileName <- nonEmptyStringGen
-    enclosureName <- nonEmptyStringGen
+    enclosureName <- Gen.uuid.map(_.toString)
     packageName <- nonEmptyStringGen
     line <- Gen.posNum[Int]
   } yield {

--- a/core/src/test/scala/io/odin/loggers/RouterLoggerSpec.scala
+++ b/core/src/test/scala/io/odin/loggers/RouterLoggerSpec.scala
@@ -75,14 +75,12 @@ class RouterLoggerSpec extends OdinSpec {
   it should "noop logs with level less than set" in {
     val logger = new WriterTLogger[IO]
 
-    forAll { (level: Level, msg: LoggerMessage) =>
+    forAll { (level: Level, msgs: List[LoggerMessage]) =>
       val log = logger.withMinimalLevel(level)
-      val written = log.log(msg).written.unsafeRunSync()
-      if (msg.level >= level) {
-        written shouldBe List(msg)
-      } else {
-        written shouldBe Nil
-      }
+      val written = msgs.traverse(log.log).written.unsafeRunSync()
+      val batchWritten = log.log(msgs).written.unsafeRunSync()
+      written shouldBe msgs.filter(_.level >= level)
+      batchWritten shouldBe written
     }
   }
 

--- a/core/src/test/scala/io/odin/loggers/RouterLoggerSpec.scala
+++ b/core/src/test/scala/io/odin/loggers/RouterLoggerSpec.scala
@@ -4,8 +4,8 @@ import cats.data.WriterT
 import cats.effect.{IO, Timer}
 import cats.instances.list._
 import cats.syntax.all._
-import io.odin.{Level, Logger, LoggerMessage, OdinSpec}
 import io.odin.syntax._
+import io.odin.{Level, Logger, LoggerMessage, OdinSpec}
 
 class RouterLoggerSpec extends OdinSpec {
   implicit val timer: Timer[IO] = IO.timer(scala.concurrent.ExecutionContext.global)
@@ -16,48 +16,59 @@ class RouterLoggerSpec extends OdinSpec {
     def log(msg: LoggerMessage): F[Unit] = WriterT.tell(List(loggerName -> msg))
   }
 
-  it should "route logs to corresponding loggers" in {
-    forAll { (p1: (String, LoggerMessage), p2: (String, LoggerMessage)) =>
-      val routerLogger = RouterLogger[F] {
-        case msg if msg == p1._2 => TestLogger(p1._1)
-        case msg if msg == p2._2 => TestLogger(p2._1)
-      }
-
-      val List(written1) = routerLogger.log(p1._2).written.unsafeRunSync()
-      val List(written2) = routerLogger.log(p2._2).written.unsafeRunSync()
-
-      written1 shouldBe p1
-      written2 shouldBe p2
-    }
-  }
-
   it should "route based on the package" in {
-    forAll { (p1: (String, LoggerMessage), p2: (String, LoggerMessage)) =>
-      val routerLogger = RouterLogger.packageRoutingLogger[F](
-        p1._2.position.packageName -> TestLogger(p1._1),
-        p2._2.position.packageName -> TestLogger(p2._1)
-      )
+    forAll { ls: List[LoggerMessage] =>
+      val withEnclosure = ls.groupBy(_.position.enclosureName)
+      val routerLogger = RouterLogger
+        .packageRoutingLogger[F](
+          withEnclosure.toList.map {
+            case (key, _) => key -> TestLogger(key)
+          }: _*
+        )
+        .withNoopFallback
 
-      val List(written1) = routerLogger.log(p1._2).written.unsafeRunSync()
-      val List(written2) = routerLogger.log(p2._2).written.unsafeRunSync()
+      val written = ls.traverse(routerLogger.log).written.unsafeRunSync()
+      val batchWritten = routerLogger.log(ls).written.unsafeRunSync()
 
-      written1 shouldBe p1
-      written2 shouldBe p2
+      written shouldBe ls.map(msg => msg.position.enclosureName -> msg)
+      batchWritten should contain theSameElementsAs written
     }
   }
 
   it should "route based on the class" in {
-    forAll { (msg: String, loggerName1: String, loggerName2: String) =>
-      val routerLogger = RouterLogger.classRoutingLogger[F](
-        classOf[RouterLoggerSpec] -> TestLogger(loggerName1),
-        classOf[TestClass[F]] -> TestLogger(loggerName2)
-      )
+    forAll(nonEmptyStringGen, nonEmptyStringGen, nonEmptyStringGen) {
+      (msg: String, loggerName1: String, loggerName2: String) =>
+        val routerLogger = RouterLogger
+          .classRoutingLogger[F](
+            classOf[RouterLoggerSpec] -> TestLogger(loggerName1),
+            classOf[TestClass[F]] -> TestLogger(loggerName2)
+          )
+          .withNoopFallback
 
-      val List((ln1, _)) = routerLogger.info(msg).written.unsafeRunSync()
-      val List((ln2, _)) = (new TestClass[F](routerLogger)).log(msg).written.unsafeRunSync()
+        val List((ln1, _)) = routerLogger.info(msg).written.unsafeRunSync()
+        val List((ln2, _)) = (new TestClass[F](routerLogger)).log(msg).written.unsafeRunSync()
 
-      ln1 shouldBe loggerName1
-      ln2 shouldBe loggerName2
+        ln1 shouldBe loggerName1
+        ln2 shouldBe loggerName2
+    }
+  }
+
+  it should "route based on the level" in {
+    forAll { (ls: List[LoggerMessage]) =>
+      val withLevels = ls.groupBy(_.level)
+      val routerLogger = RouterLogger
+        .levelRoutingLogger[F](
+          withLevels.map {
+            case (key, _) => key -> TestLogger(key.show)
+          }
+        )
+        .withNoopFallback
+
+      val written = ls.traverse(routerLogger.log).written.unsafeRunSync()
+      val batchWritten = routerLogger.log(ls).written.unsafeRunSync()
+
+      written.toMap shouldBe ls.map(msg => msg.level.show -> msg).toMap
+      batchWritten should contain theSameElementsAs written
     }
   }
 
@@ -72,6 +83,21 @@ class RouterLoggerSpec extends OdinSpec {
       } else {
         written shouldBe Nil
       }
+    }
+  }
+
+  it should "fallback to provided logger" in {
+    forAll { ls: List[LoggerMessage] =>
+      val fallback = TestLogger("fallback")
+      val routerLogger = RouterLogger
+        .packageRoutingLogger[F]()
+        .withFallback(fallback)
+
+      val written = ls.traverse(routerLogger.log).written.unsafeRunSync()
+      val batchWritten = routerLogger.log(ls).written.unsafeRunSync()
+
+      written shouldBe ls.map(msg => "fallback" -> msg)
+      batchWritten should contain theSameElementsAs written
     }
   }
 }


### PR DESCRIPTION
- Git rid of `PartialFunction`-based routing for the sake of supporting batching
- Add the fallback logger parameter through the builder. It's used when message didn't match any of the routes