### PR TITLE
Add slf4j bridge

### DIFF
--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Run tests
       shell: bash
       run: |
-        JAVA_TOOL_OPTIONS=-Dfile.encoding=UTF8 sbt coverage +test
+        JAVA_TOOL_OPTIONS=-Dfile.encoding=UTF8 sbt coverage +test docs/mdoc
         sbt coverageReport coverageAggregate
     - uses: codecov/codecov-action@v1
       if: matrix.os != 'windows-latest' #doesn't work properly on Windows

--- a/build.sbt
+++ b/build.sbt
@@ -140,7 +140,7 @@ lazy val docs = (project in file("odin-docs"))
     ),
     mdocOut := file(".")
   )
-  .dependsOn(`odin-core`, `odin-json`, `odin-zio`, `odin-monix`)
+  .dependsOn(`odin-core`, `odin-json`, `odin-zio`, `odin-monix`, `odin-slf4j`)
   .enablePlugins(MdocPlugin)
 
 lazy val examples = (project in file("examples"))

--- a/build.sbt
+++ b/build.sbt
@@ -11,6 +11,7 @@ lazy val versions = new {
   val catsScalacheck = "0.2.0"
   val zio = "1.0.0-RC17"
   val zioCats = "2.0.0.0-RC10"
+  val slf4j = "1.7.30"
 }
 
 lazy val scalaVersions = List("2.13.1", "2.12.10")
@@ -38,6 +39,8 @@ lazy val monix = "io.monix" %% "monix" % versions.monix
 lazy val perfolation = "com.outr" %% "perfolation" % "1.1.5"
 
 lazy val circeCore = "io.circe" %% "circe-core" % "0.12.3"
+
+lazy val slf4j = "org.slf4j" % "slf4j-api" % versions.slf4j
 
 lazy val catsScalacheck = "io.chrisdavenport" %% "cats-scalacheck" % versions.catsScalacheck % Test
 
@@ -112,6 +115,13 @@ lazy val `odin-monix` = (project in file("monix"))
   .settings(sharedSettings)
   .settings(
     libraryDependencies += monix
+  )
+  .dependsOn(`odin-core` % "compile->compile;test->test")
+
+lazy val `odin-slf4j` = (project in file("slf4j"))
+  .settings(sharedSettings)
+  .settings(
+    libraryDependencies += slf4j
   )
   .dependsOn(`odin-core` % "compile->compile;test->test")
 

--- a/build.sbt
+++ b/build.sbt
@@ -154,8 +154,8 @@ lazy val examples = (project in file("examples"))
 lazy val odin = (project in file("."))
   .settings(sharedSettings)
   .settings(noPublish)
-  .dependsOn(`odin-core`, `odin-json`, `odin-zio`, `odin-monix`)
-  .aggregate(`odin-core`, `odin-json`, `odin-zio`, `odin-monix`, benchmarks, examples)
+  .dependsOn(`odin-core`, `odin-json`, `odin-zio`, `odin-monix`, `odin-slf4j`)
+  .aggregate(`odin-core`, `odin-json`, `odin-zio`, `odin-monix`, `odin-slf4j`, benchmarks, examples)
 
 def scalacOptionsVersion(scalaVersion: String) =
   Seq(

--- a/core/src/main/scala/io/odin/formatter/Formatter.scala
+++ b/core/src/main/scala/io/odin/formatter/Formatter.scala
@@ -13,13 +13,14 @@ trait Formatter {
 object Formatter {
   val default: Formatter = (msg: LoggerMessage) => {
     val ctx = formatCtx(msg.context)
+    val lineNumber = if (msg.position.line >= 0) p":${msg.position.line}" else ""
     msg.exception match {
       case Some(t) =>
         val formattedThrowable = formatThrowable(t)
-        p"${msg.timestamp.t.F}T${msg.timestamp.t.T} [${msg.threadName}] ${msg.level.show} ${msg.position.enclosureName}:${msg.position.line} - ${msg.message.value} $ctx${System
+        p"${msg.timestamp.t.F}T${msg.timestamp.t.T} [${msg.threadName}] ${msg.level.show} ${msg.position.enclosureName}$lineNumber - ${msg.message.value} $ctx${System
           .lineSeparator()}${formattedThrowable.toString}"
       case None =>
-        p"${msg.timestamp.t.F}T${msg.timestamp.t.T} [${msg.threadName}] ${msg.level.show} ${msg.position.enclosureName}:${msg.position.line} - ${msg.message.value}$ctx"
+        p"${msg.timestamp.t.F}T${msg.timestamp.t.T} [${msg.threadName}] ${msg.level.show} ${msg.position.enclosureName}$lineNumber - ${msg.message.value}$ctx"
     }
   }
 

--- a/slf4j/src/main/scala/io/odin/slf4j/OdinLoggerAdapter.scala
+++ b/slf4j/src/main/scala/io/odin/slf4j/OdinLoggerAdapter.scala
@@ -1,0 +1,120 @@
+package io.odin.slf4j
+
+import java.util.concurrent.TimeUnit
+
+import cats.Eval
+import cats.effect.{ConcurrentEffect, Timer}
+import cats.syntax.all._
+import io.odin.meta.Position
+import io.odin.{Level, LoggerMessage, Logger => OdinLogger}
+import org.slf4j.Logger
+import org.slf4j.helpers.{FormattingTuple, MarkerIgnoringBase, MessageFormatter}
+
+case class OdinLoggerAdapter[F[_]](loggerName: String, underlying: OdinLogger[F])(
+    implicit F: ConcurrentEffect[F],
+    timer: Timer[F]
+) extends MarkerIgnoringBase
+    with Logger {
+
+  private def run(level: Level, msg: String, t: Option[Throwable] = None): Unit =
+    F.toIO(for {
+        timestamp <- timer.clock.realTime(TimeUnit.MILLISECONDS)
+        _ <- underlying.log(
+          LoggerMessage(
+            level = level,
+            message = Eval.now(msg),
+            context = Map.empty,
+            exception = t,
+            position = Position(
+              fileName = loggerName,
+              enclosureName = loggerName,
+              packageName = loggerName,
+              line = -1
+            ),
+            threadName = Thread.currentThread().getName,
+            timestamp = timestamp
+          )
+        )
+      } yield {
+        ()
+      })
+      .unsafeRunSync()
+
+  private def runFormatted(level: Level, tuple: FormattingTuple): Unit =
+    run(level, tuple.getMessage, Option(tuple.getThrowable))
+
+  def isTraceEnabled: Boolean = underlying.minLevel <= Level.Trace
+
+  def trace(msg: String): Unit = run(Level.Trace, msg)
+
+  def trace(format: String, arg: Any): Unit = runFormatted(Level.Trace, MessageFormatter.format(format, arg))
+
+  def trace(format: String, arg1: Any, arg2: Any): Unit =
+    runFormatted(Level.Trace, MessageFormatter.format(format, arg1, arg2))
+
+  def trace(format: String, arguments: AnyRef*): Unit =
+    runFormatted(Level.Trace, MessageFormatter.arrayFormat(format, arguments.toArray))
+
+  def trace(msg: String, t: Throwable): Unit =
+    run(Level.Trace, msg, Option(t))
+
+  def isDebugEnabled: Boolean = underlying.minLevel <= Level.Debug
+
+  def debug(msg: String): Unit = run(Level.Debug, msg)
+
+  def debug(format: String, arg: Any): Unit = runFormatted(Level.Debug, MessageFormatter.format(format, arg))
+
+  def debug(format: String, arg1: Any, arg2: Any): Unit =
+    runFormatted(Level.Debug, MessageFormatter.format(format, arg1, arg2))
+
+  def debug(format: String, arguments: AnyRef*): Unit =
+    runFormatted(Level.Debug, MessageFormatter.arrayFormat(format, arguments.toArray))
+
+  def debug(msg: String, t: Throwable): Unit =
+    run(Level.Debug, msg, Option(t))
+
+  def isInfoEnabled: Boolean = underlying.minLevel <= Level.Info
+
+  def info(msg: String): Unit = run(Level.Info, msg)
+
+  def info(format: String, arg: Any): Unit = runFormatted(Level.Info, MessageFormatter.format(format, arg))
+
+  def info(format: String, arg1: Any, arg2: Any): Unit =
+    runFormatted(Level.Info, MessageFormatter.format(format, arg1, arg2))
+
+  def info(format: String, arguments: AnyRef*): Unit =
+    runFormatted(Level.Info, MessageFormatter.arrayFormat(format, arguments.toArray))
+
+  def info(msg: String, t: Throwable): Unit =
+    run(Level.Info, msg, Option(t))
+
+  def isWarnEnabled: Boolean = underlying.minLevel <= Level.Warn
+
+  def warn(msg: String): Unit = run(Level.Warn, msg)
+
+  def warn(format: String, arg: Any): Unit = runFormatted(Level.Warn, MessageFormatter.format(format, arg))
+
+  def warn(format: String, arg1: Any, arg2: Any): Unit =
+    runFormatted(Level.Warn, MessageFormatter.format(format, arg1, arg2))
+
+  def warn(format: String, arguments: AnyRef*): Unit =
+    runFormatted(Level.Warn, MessageFormatter.arrayFormat(format, arguments.toArray))
+
+  def warn(msg: String, t: Throwable): Unit =
+    run(Level.Warn, msg, Option(t))
+
+  def isErrorEnabled: Boolean = underlying.minLevel <= Level.Error
+
+  def error(msg: String): Unit = run(Level.Error, msg)
+
+  def error(format: String, arg: Any): Unit = runFormatted(Level.Error, MessageFormatter.format(format, arg))
+
+  def error(format: String, arg1: Any, arg2: Any): Unit =
+    runFormatted(Level.Error, MessageFormatter.format(format, arg1, arg2))
+
+  def error(format: String, arguments: AnyRef*): Unit =
+    runFormatted(Level.Error, MessageFormatter.arrayFormat(format, arguments.toArray))
+
+  def error(msg: String, t: Throwable): Unit =
+    run(Level.Error, msg, Option(t))
+}

--- a/slf4j/src/main/scala/io/odin/slf4j/OdinLoggerBinder.scala
+++ b/slf4j/src/main/scala/io/odin/slf4j/OdinLoggerBinder.scala
@@ -1,0 +1,21 @@
+package io.odin.slf4j
+
+import cats.effect.{ConcurrentEffect, Timer}
+import io.odin.Logger
+import org.slf4j.ILoggerFactory
+import org.slf4j.spi.LoggerFactoryBinder
+
+abstract class OdinLoggerBinder[F[_]] extends LoggerFactoryBinder {
+
+  implicit def timer: Timer[F]
+  implicit def F: ConcurrentEffect[F]
+
+  def loggers: PartialFunction[String, Logger[F]]
+
+  private val factoryClass = classOf[OdinLoggerFactory[F]].getName
+
+  override def getLoggerFactory: ILoggerFactory = new OdinLoggerFactory[F](loggers)
+
+  override def getLoggerFactoryClassStr: String = factoryClass
+
+}

--- a/slf4j/src/main/scala/io/odin/slf4j/OdinLoggerFactory.scala
+++ b/slf4j/src/main/scala/io/odin/slf4j/OdinLoggerFactory.scala
@@ -1,0 +1,12 @@
+package io.odin.slf4j
+
+import cats.effect.{ConcurrentEffect, Timer}
+import io.odin.{Logger => OdinLogger}
+import org.slf4j.{ILoggerFactory, Logger}
+
+class OdinLoggerFactory[F[_]: ConcurrentEffect: Timer](loggers: PartialFunction[String, OdinLogger[F]])
+    extends ILoggerFactory {
+  def getLogger(name: String): Logger = {
+    new OdinLoggerAdapter[F](name, loggers.applyOrElse(name, (_: String) => OdinLogger.noop))
+  }
+}

--- a/slf4j/src/test/scala/io/odin/slf4j/BufferingLogger.scala
+++ b/slf4j/src/test/scala/io/odin/slf4j/BufferingLogger.scala
@@ -1,0 +1,15 @@
+package io.odin.slf4j
+
+import cats.effect.concurrent.Ref
+import cats.effect.{Sync, Timer}
+import io.odin.LoggerMessage
+import io.odin.loggers.DefaultLogger
+
+import scala.collection.immutable.Queue
+
+class BufferingLogger[F[_]: Timer](implicit F: Sync[F]) extends DefaultLogger[F] {
+
+  val buffer: Ref[F, Queue[LoggerMessage]] = Ref.unsafe[F, Queue[LoggerMessage]](Queue.empty)
+
+  def log(msg: LoggerMessage): F[Unit] = buffer.update(_.enqueue(msg))
+}

--- a/slf4j/src/test/scala/io/odin/slf4j/Slf4jSpec.scala
+++ b/slf4j/src/test/scala/io/odin/slf4j/Slf4jSpec.scala
@@ -65,15 +65,15 @@ class Slf4jSpec extends OdinSpec {
   }
 
   it should "format logs with two arguments" in {
-    forAll { (msgs: List[LoggerMessage], i: Int) =>
+    forAll { (msgs: List[LoggerMessage], i: String) =>
       val (logger, buffer) = getLogger
       msgs.foreach { msg =>
         msg.level match {
-          case Level.Trace => logger.trace("{} {}", msg.message.value, i)
-          case Level.Debug => logger.debug("{} {}", msg.message.value, i)
-          case Level.Info  => logger.info("{} {}", msg.message.value, i)
-          case Level.Warn  => logger.warn("{} {}", msg.message.value, i)
-          case Level.Error => logger.error("{} {}", msg.message.value, i)
+          case Level.Trace => logger.trace("{} {}", msg.message.value: Any, i: Any)
+          case Level.Debug => logger.debug("{} {}", msg.message.value: Any, i: Any)
+          case Level.Info  => logger.info("{} {}", msg.message.value: Any, i: Any)
+          case Level.Warn  => logger.warn("{} {}", msg.message.value: Any, i: Any)
+          case Level.Error => logger.error("{} {}", msg.message.value: Any, i: Any)
         }
       }
 
@@ -84,7 +84,7 @@ class Slf4jSpec extends OdinSpec {
   }
 
   it should "format logs with multiple arguments" in {
-    forAll { (msgs: List[LoggerMessage], i: Int, i2: Int) =>
+    forAll { (msgs: List[LoggerMessage], i: String, i2: String) =>
       val (logger, buffer) = getLogger
       msgs.foreach { msg =>
         msg.level match {

--- a/slf4j/src/test/scala/io/odin/slf4j/Slf4jSpec.scala
+++ b/slf4j/src/test/scala/io/odin/slf4j/Slf4jSpec.scala
@@ -29,6 +29,25 @@ class Slf4jSpec extends OdinSpec {
 
   }
 
+  it should "log exceptions" in {
+    forAll { (msgs: List[LoggerMessage], t: Throwable) =>
+      val (logger, buffer) = getLogger
+      msgs.foreach { msg =>
+        msg.level match {
+          case Level.Trace => logger.trace(msg.message.value, t)
+          case Level.Debug => logger.debug(msg.message.value, t)
+          case Level.Info  => logger.info(msg.message.value, t)
+          case Level.Warn  => logger.warn(msg.message.value, t)
+          case Level.Error => logger.error(msg.message.value, t)
+        }
+      }
+
+      buffer.get.unsafeRunSync().map(msg => (msg.message.value, msg.level, msg.exception)) shouldBe msgs.map(msg =>
+        (msg.message.value, msg.level, Some(t))
+      )
+    }
+  }
+
   it should "resolve minimal level" in {
     LoggerFactory.getLogger(Level.Trace.toString).isTraceEnabled shouldBe true
 

--- a/slf4j/src/test/scala/io/odin/slf4j/Slf4jSpec.scala
+++ b/slf4j/src/test/scala/io/odin/slf4j/Slf4jSpec.scala
@@ -29,6 +29,79 @@ class Slf4jSpec extends OdinSpec {
 
   }
 
+  it should "resolve minimal level" in {
+    LoggerFactory.getLogger(Level.Trace.toString).isTraceEnabled shouldBe true
+
+    LoggerFactory.getLogger(Level.Debug.toString).isDebugEnabled shouldBe true
+    LoggerFactory.getLogger(Level.Debug.toString).isTraceEnabled shouldBe false
+
+    LoggerFactory.getLogger(Level.Info.toString).isInfoEnabled shouldBe true
+    LoggerFactory.getLogger(Level.Info.toString).isDebugEnabled shouldBe false
+
+    LoggerFactory.getLogger(Level.Warn.toString).isWarnEnabled shouldBe true
+    LoggerFactory.getLogger(Level.Warn.toString).isInfoEnabled shouldBe false
+
+    LoggerFactory.getLogger(Level.Error.toString).isErrorEnabled shouldBe true
+    LoggerFactory.getLogger(Level.Error.toString).isWarnEnabled shouldBe false
+  }
+
+  it should "format logs" in {
+    forAll { msgs: List[LoggerMessage] =>
+      val (logger, buffer) = getLogger
+      msgs.foreach { msg =>
+        msg.level match {
+          case Level.Trace => logger.trace("{}", msg.message.value)
+          case Level.Debug => logger.debug("{}", msg.message.value)
+          case Level.Info  => logger.info("{}", msg.message.value)
+          case Level.Warn  => logger.warn("{}", msg.message.value)
+          case Level.Error => logger.error("{}", msg.message.value)
+        }
+      }
+
+      buffer.get.unsafeRunSync().map(msg => (msg.message.value, msg.level)) shouldBe msgs.map(msg =>
+        (msg.message.value, msg.level)
+      )
+    }
+  }
+
+  it should "format logs with two arguments" in {
+    forAll { (msgs: List[LoggerMessage], i: Int) =>
+      val (logger, buffer) = getLogger
+      msgs.foreach { msg =>
+        msg.level match {
+          case Level.Trace => logger.trace("{} {}", msg.message.value, i)
+          case Level.Debug => logger.debug("{} {}", msg.message.value, i)
+          case Level.Info  => logger.info("{} {}", msg.message.value, i)
+          case Level.Warn  => logger.warn("{} {}", msg.message.value, i)
+          case Level.Error => logger.error("{} {}", msg.message.value, i)
+        }
+      }
+
+      buffer.get.unsafeRunSync().map(msg => (msg.message.value, msg.level)) shouldBe msgs.map(msg =>
+        (s"${msg.message.value} $i", msg.level)
+      )
+    }
+  }
+
+  it should "format logs with multiple arguments" in {
+    forAll { (msgs: List[LoggerMessage], i: Int, i2: Int) =>
+      val (logger, buffer) = getLogger
+      msgs.foreach { msg =>
+        msg.level match {
+          case Level.Trace => logger.trace("{} {} {}", msg.message.value, i, i2)
+          case Level.Debug => logger.debug("{} {} {}", msg.message.value, i, i2)
+          case Level.Info  => logger.info("{} {} {}", msg.message.value, i, i2)
+          case Level.Warn  => logger.warn("{} {} {}", msg.message.value, i, i2)
+          case Level.Error => logger.error("{} {} {}", msg.message.value, i, i2)
+        }
+      }
+
+      buffer.get.unsafeRunSync().map(msg => (msg.message.value, msg.level)) shouldBe msgs.map(msg =>
+        (s"${msg.message.value} $i $i2", msg.level)
+      )
+    }
+  }
+
   def getLogger: (Logger, Ref[IO, Queue[LoggerMessage]]) = {
     val logger = LoggerFactory.getLogger(this.getClass).asInstanceOf[OdinLoggerAdapter[IO]]
     (logger, logger.underlying.asInstanceOf[BufferingLogger[IO]].buffer)

--- a/slf4j/src/test/scala/io/odin/slf4j/Slf4jSpec.scala
+++ b/slf4j/src/test/scala/io/odin/slf4j/Slf4jSpec.scala
@@ -1,0 +1,37 @@
+package io.odin.slf4j
+
+import cats.effect.IO
+import cats.effect.concurrent.Ref
+import io.odin.{Level, LoggerMessage, OdinSpec}
+import org.slf4j.{Logger, LoggerFactory}
+
+import scala.collection.immutable.Queue
+
+class Slf4jSpec extends OdinSpec {
+
+  it should "log with correct level" in {
+    forAll { msgs: List[LoggerMessage] =>
+      val (logger, buffer) = getLogger
+      msgs.foreach { msg =>
+        msg.level match {
+          case Level.Trace => logger.trace(msg.message.value)
+          case Level.Debug => logger.debug(msg.message.value)
+          case Level.Info  => logger.info(msg.message.value)
+          case Level.Warn  => logger.warn(msg.message.value)
+          case Level.Error => logger.error(msg.message.value)
+        }
+      }
+
+      buffer.get.unsafeRunSync().map(msg => (msg.message.value, msg.level)) shouldBe msgs.map(msg =>
+        (msg.message.value, msg.level)
+      )
+    }
+
+  }
+
+  def getLogger: (Logger, Ref[IO, Queue[LoggerMessage]]) = {
+    val logger = LoggerFactory.getLogger(this.getClass).asInstanceOf[OdinLoggerAdapter[IO]]
+    (logger, logger.underlying.asInstanceOf[BufferingLogger[IO]].buffer)
+  }
+
+}

--- a/slf4j/src/test/scala/org/slf4j/impl/StaticLoggerBinder.scala
+++ b/slf4j/src/test/scala/org/slf4j/impl/StaticLoggerBinder.scala
@@ -1,0 +1,28 @@
+package org.slf4j.impl
+
+import cats.effect.{ConcurrentEffect, ContextShift, IO, Timer}
+import io.odin._
+import io.odin.slf4j.{BufferingLogger, OdinLoggerBinder}
+
+import scala.concurrent.ExecutionContext
+
+class StaticLoggerBinder extends OdinLoggerBinder[IO] {
+
+  val ec: ExecutionContext = scala.concurrent.ExecutionContext.global
+  implicit val timer: Timer[IO] = IO.timer(ec)
+  implicit val cs: ContextShift[IO] = IO.contextShift(ec)
+  implicit val F: ConcurrentEffect[IO] = IO.ioConcurrentEffect
+
+  val loggers: PartialFunction[String, Logger[IO]] = {
+    case _ =>
+      new BufferingLogger[IO]()
+  }
+}
+
+object StaticLoggerBinder extends StaticLoggerBinder {
+
+  var REQUESTED_API_VERSION: String = "1.7"
+
+  def getSingleton: StaticLoggerBinder = this
+
+}

--- a/slf4j/src/test/scala/org/slf4j/impl/StaticLoggerBinder.scala
+++ b/slf4j/src/test/scala/org/slf4j/impl/StaticLoggerBinder.scala
@@ -14,6 +14,11 @@ class StaticLoggerBinder extends OdinLoggerBinder[IO] {
   implicit val F: ConcurrentEffect[IO] = IO.ioConcurrentEffect
 
   val loggers: PartialFunction[String, Logger[IO]] = {
+    case Level.Trace.toString => consoleLogger(minLevel = Level.Trace)
+    case Level.Debug.toString => consoleLogger(minLevel = Level.Debug)
+    case Level.Info.toString  => consoleLogger(minLevel = Level.Info)
+    case Level.Warn.toString  => consoleLogger(minLevel = Level.Warn)
+    case Level.Error.toString => consoleLogger(minLevel = Level.Error)
     case _ =>
       new BufferingLogger[IO]()
   }


### PR DESCRIPTION
Users would need to create `org.slf4j.impl.StaticLoggerBinder` on their own, but it's not a huge deal. I will add it to the documentation.

An example is in a spec.