### PR TITLE
Fix min level logging in odin-slf4j

### DIFF
--- a/core/src/main/scala/io/odin/config/package.scala
+++ b/core/src/main/scala/io/odin/config/package.scala
@@ -7,6 +7,7 @@ import cats.syntax.all._
 import io.odin.loggers.DefaultLogger
 
 package object config {
+
   /**
     * Route logs to specific logger based on the fully qualified package name.
     * Beware of O(n) complexity due to the partial matching done during the logging

--- a/core/src/main/scala/io/odin/loggers/AsyncLogger.scala
+++ b/core/src/main/scala/io/odin/loggers/AsyncLogger.scala
@@ -47,6 +47,7 @@ case class AsyncLogger[F[_]](queue: ConcurrentQueue[F, LoggerMessage], timeWindo
 }
 
 object AsyncLogger {
+
   /**
     * Create async logger and start internal loop of sending events down the chain from the buffer once
     * `Resource` is used.

--- a/core/src/main/scala/io/odin/loggers/ContextualLogger.scala
+++ b/core/src/main/scala/io/odin/loggers/ContextualLogger.scala
@@ -45,6 +45,7 @@ trait WithContext[F[_]] {
 }
 
 object WithContext {
+
   /**
     * Default implementation of `WithContext` that works for any `F[_]` with `ApplicativeAsk` instance and
     * instance of [[HasContext]] for environment of this `ApplicativeAsk`

--- a/core/src/main/scala/io/odin/meta/Render.scala
+++ b/core/src/main/scala/io/odin/meta/Render.scala
@@ -10,6 +10,7 @@ trait Render[M] {
 }
 
 object Render extends LowPriorityRender {
+
   /**
     * Construct [[Render]] using default `.toString` method
     */
@@ -19,6 +20,7 @@ object Render extends LowPriorityRender {
 }
 
 trait LowPriorityRender {
+
   /**
     * Automatically derive [[Render]] instance given `cats.Show`
     */

--- a/core/src/main/scala/io/odin/package.scala
+++ b/core/src/main/scala/io/odin/package.scala
@@ -8,6 +8,7 @@ import io.odin.syntax._
 import scala.concurrent.duration._
 
 package object odin {
+
   /**
     * Basic console logger that prints to STDOUT & STDERR
     * @param formatter formatter to use for log messages

--- a/core/src/main/scala/io/odin/syntax/package.scala
+++ b/core/src/main/scala/io/odin/syntax/package.scala
@@ -8,6 +8,7 @@ import scala.concurrent.duration._
 
 package object syntax {
   implicit class LoggerSyntax[F[_]](logger: Logger[F]) {
+
     /**
       * Create logger that adds constant context to each log record
       * @param ctx constant context
@@ -64,6 +65,7 @@ package object syntax {
     * Syntax for loggers suspended in `Resource` (i.e. `AsyncLogger` or `FileLogger`)
     */
   implicit class ResourceLoggerSyntax[F[_]](resource: Resource[F, Logger[F]]) {
+
     /**
       * Create async logger that buffers the messages up to the limit (if any) and flushes it down the chain each `timeWindow`
       * @param timeWindow pause between async buffer flushing

--- a/core/src/test/scala/io/odin/loggers/LoggerTests.scala
+++ b/core/src/test/scala/io/odin/loggers/LoggerTests.scala
@@ -17,11 +17,10 @@ trait LoggerTests[F[_]] extends Laws {
       eqF: Eq[List[LoggerMessage]]
   ): RuleSet = new SimpleRuleSet(
     "logger",
-    "checks minLevel" -> Prop.forAll(
-      (msg: LoggerMessage, level: Level) => loggerLaws.checksMinLevel(logger, msg, level)
+    "checks minLevel" -> Prop.forAll((msg: LoggerMessage, level: Level) => loggerLaws.checksMinLevel(logger, msg, level)
     ),
-    "log(list) <-> list.traverse(log)" -> Prop.forAll(
-      (msgs: List[LoggerMessage]) => loggerLaws.batchEqualsToTraverse(logger, msgs)
+    "log(list) <-> list.traverse(log)" -> Prop.forAll((msgs: List[LoggerMessage]) =>
+      loggerLaws.batchEqualsToTraverse(logger, msgs)
     )
   )
 }

--- a/examples/src/main/scala/io/odin/examples/ContramapExample.scala
+++ b/examples/src/main/scala/io/odin/examples/ContramapExample.scala
@@ -9,6 +9,7 @@ import io.odin.syntax._
   * Modify logger message before it's written
   */
 object ContramapExample extends IOApp {
+
   /**
     * This logger always appends " World" string to each message
     */

--- a/examples/src/main/scala/io/odin/examples/WithContextual.scala
+++ b/examples/src/main/scala/io/odin/examples/WithContextual.scala
@@ -16,6 +16,7 @@ import io.odin.syntax._
   * the log
   */
 object WithContextual extends IOApp {
+
   /**
     * Simple Reader monad with environment being context `Map[String, String]`
     */

--- a/json/src/main/scala/io/odin/json/Formatter.scala
+++ b/json/src/main/scala/io/odin/json/Formatter.scala
@@ -10,17 +10,16 @@ import perfolation._
 
 object Formatter {
   implicit val loggerMessageEncoder: Encoder[LoggerMessage] =
-    Encoder.forProduct7("level", "message", "context", "exception", "position", "thread_name", "timestamp")(
-      m =>
-        (
-          m.level.show,
-          m.message.value,
-          m.context,
-          m.exception.map(t => formatThrowable(t).toString()),
-          p"${m.position.enclosureName}:${m.position.line}",
-          m.threadName,
-          p"${m.timestamp.t.F}T${m.timestamp.t.T}"
-        )
+    Encoder.forProduct7("level", "message", "context", "exception", "position", "thread_name", "timestamp")(m =>
+      (
+        m.level.show,
+        m.message.value,
+        m.context,
+        m.exception.map(t => formatThrowable(t).toString()),
+        p"${m.position.enclosureName}:${m.position.line}",
+        m.threadName,
+        p"${m.timestamp.t.F}T${m.timestamp.t.T}"
+      )
     )
 
   val json: OFormatter = (msg: LoggerMessage) => msg.asJson.noSpaces

--- a/monix/src/main/scala/io/odin/monix/package.scala
+++ b/monix/src/main/scala/io/odin/monix/package.scala
@@ -7,6 +7,7 @@ import cats.effect.Resource
 import scala.concurrent.duration._
 
 package object monix {
+
   /**
     * See `io.odin.consoleLogger`
     */

--- a/slf4j/src/main/scala/io/odin/slf4j/OdinLoggerAdapter.scala
+++ b/slf4j/src/main/scala/io/odin/slf4j/OdinLoggerAdapter.scala
@@ -17,7 +17,7 @@ case class OdinLoggerAdapter[F[_]](loggerName: String, underlying: OdinLogger[F]
     with Logger {
 
   private def run(level: Level, msg: String, t: Option[Throwable] = None): Unit =
-    F.toIO(for {
+    F.toIO(F.whenA(level >= underlying.minLevel)(for {
         timestamp <- timer.clock.realTime(TimeUnit.MILLISECONDS)
         _ <- underlying.log(
           LoggerMessage(
@@ -37,7 +37,7 @@ case class OdinLoggerAdapter[F[_]](loggerName: String, underlying: OdinLogger[F]
         )
       } yield {
         ()
-      })
+      }))
       .unsafeRunSync()
 
   private def runFormatted(level: Level, tuple: FormattingTuple): Unit =

--- a/slf4j/src/test/scala/io/odin/slf4j/BufferingLogger.scala
+++ b/slf4j/src/test/scala/io/odin/slf4j/BufferingLogger.scala
@@ -2,12 +2,13 @@ package io.odin.slf4j
 
 import cats.effect.concurrent.Ref
 import cats.effect.{Sync, Timer}
-import io.odin.LoggerMessage
+import io.odin.{Level, LoggerMessage}
 import io.odin.loggers.DefaultLogger
 
 import scala.collection.immutable.Queue
 
-class BufferingLogger[F[_]: Timer](implicit F: Sync[F]) extends DefaultLogger[F] {
+class BufferingLogger[F[_]: Timer](override val minLevel: Level)(implicit F: Sync[F])
+    extends DefaultLogger[F](minLevel) {
 
   val buffer: Ref[F, Queue[LoggerMessage]] = Ref.unsafe[F, Queue[LoggerMessage]](Queue.empty)
 

--- a/slf4j/src/test/scala/org/slf4j/impl/StaticLoggerBinder.scala
+++ b/slf4j/src/test/scala/org/slf4j/impl/StaticLoggerBinder.scala
@@ -14,13 +14,13 @@ class StaticLoggerBinder extends OdinLoggerBinder[IO] {
   implicit val F: ConcurrentEffect[IO] = IO.ioConcurrentEffect
 
   val loggers: PartialFunction[String, Logger[IO]] = {
-    case Level.Trace.toString => consoleLogger(minLevel = Level.Trace)
-    case Level.Debug.toString => consoleLogger(minLevel = Level.Debug)
-    case Level.Info.toString  => consoleLogger(minLevel = Level.Info)
-    case Level.Warn.toString  => consoleLogger(minLevel = Level.Warn)
-    case Level.Error.toString => consoleLogger(minLevel = Level.Error)
+    case Level.Trace.toString => new BufferingLogger[IO](Level.Trace)
+    case Level.Debug.toString => new BufferingLogger[IO](Level.Debug)
+    case Level.Info.toString  => new BufferingLogger[IO](Level.Info)
+    case Level.Warn.toString  => new BufferingLogger[IO](Level.Warn)
+    case Level.Error.toString => new BufferingLogger[IO](Level.Error)
     case _ =>
-      new BufferingLogger[IO]()
+      new BufferingLogger[IO](Level.Trace)
   }
 }
 

--- a/zio/src/main/scala/io/odin/zio/package.scala
+++ b/zio/src/main/scala/io/odin/zio/package.scala
@@ -10,6 +10,7 @@ import io.odin.formatter.Formatter
 import scala.concurrent.duration._
 
 package object zio {
+
   /**
     * See `io.odin.consoleLogger`
     */


### PR DESCRIPTION
Add check for the message log level and underlying logger log level before logging anything in `OdinLoggerAdapter`:
```scala
F.whenA(level >= underlying.minLevel)
```