### PR TITLE
Add apply method to Logger

### DIFF
--- a/core/src/main/scala/io/odin/Logger.scala
+++ b/core/src/main/scala/io/odin/Logger.scala
@@ -71,6 +71,9 @@ trait Logger[F[_]] {
 }
 
 object Logger extends Noop with LoggerInstances {
+
+  def apply[F[_]](implicit instance: Logger[F]): Logger[F] = instance
+
   implicit class LoggerOps[F[_]](logger: Logger[F]) {
     def mapK[G[_]](f: F ~> G): Logger[G] = new Logger[G] {
       val minLevel: Level = logger.minLevel


### PR DESCRIPTION
A logger can be a part of the effect constraint:
```scala
class Service[F[_]: Sync: Logger] {
   def foo: F[Unit] = implicitly[Logger[F]].info("bar")
}
```

From my point of view, it makes sense to add an apply method that removes a redundant call of `implicitly` method:
```scala
class Service[F[_]: Sync: Logger] {
   def foo: F[Unit] = Logger[F].info("bar")
}
```