### PR TITLE
Add Magnolia-based derivation

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,6 +6,7 @@ lazy val versions = new {
   val catsMtl = "0.7.0"
   val sourcecode = "0.1.9"
   val monix = "3.1.0"
+  val magnolia = "0.12.6"
   val scalaCheck = "1.14.3"
   val catsRetry = "0.3.2"
   val catsScalacheck = "0.2.0"
@@ -38,6 +39,8 @@ lazy val monixCatnap = "io.monix" %% "monix-catnap" % versions.monix
 lazy val scalaCheck = "org.scalacheck" %% "scalacheck" % versions.scalaCheck % Test
 
 lazy val monix = "io.monix" %% "monix" % versions.monix
+
+lazy val magnolia = "com.propensive" %% "magnolia" % versions.magnolia
 
 lazy val perfolation = "com.outr" %% "perfolation" % "1.1.5"
 
@@ -137,6 +140,9 @@ lazy val `odin-slf4j` = (project in file("slf4j"))
 
 lazy val `odin-extras` = (project in file("extras"))
   .settings(sharedSettings)
+  .settings(
+    libraryDependencies += magnolia
+  )
   .dependsOn(`odin-core` % "compile->compile;test->test")
 
 lazy val benchmarks = (project in file("benchmarks"))

--- a/core/src/main/scala/io/odin/meta/Render.scala
+++ b/core/src/main/scala/io/odin/meta/Render.scala
@@ -1,6 +1,9 @@
 package io.odin.meta
 
+import java.util.UUID
+
 import cats.Show
+import cats.data.NonEmptyList
 
 /**
   * Type class that defines how message of type `M` got rendered into String
@@ -15,7 +18,7 @@ trait Render[M] {
   def render(m: M): String
 }
 
-object Render extends LowPriorityRender {
+object Render extends MidPriorityRender {
 
   def apply[A](implicit instance: Render[A]): Render[A] = instance
 
@@ -30,6 +33,48 @@ object Render extends LowPriorityRender {
   def fromToString[M]: Render[M] = (m: M) => m.toString
 
   implicit val renderString: Render[String] = (m: String) => m
+
+  implicit val renderByte: Render[Byte] = fromToString
+
+  implicit val renderShort: Render[Short] = fromToString
+
+  implicit val renderInt: Render[Int] = fromToString
+
+  implicit val renderLong: Render[Long] = fromToString
+
+  implicit val renderDouble: Render[Double] = fromToString
+
+  implicit val renderFloat: Render[Float] = fromToString
+
+  implicit val renderBoolean: Render[Boolean] = fromToString
+
+  implicit val renderUuid: Render[UUID] = fromToString
+
+  implicit def renderOption[A](implicit r: Render[A]): Render[Option[A]] =
+    (m: Option[A]) => m.fold("None")(v => s"Some(${r.render(v)})")
+
+  implicit def renderSeq[A: Render]: Render[Seq[A]] =
+    fromIteratorRender("Seq", _.iterator)
+
+  implicit def renderList[A: Render]: Render[List[A]] =
+    fromIteratorRender("List", _.iterator)
+
+  implicit def renderVector[A: Render]: Render[Vector[A]] =
+    fromIteratorRender("Vector", _.iterator)
+
+  implicit def renderNonEmptyList[A: Render]: Render[NonEmptyList[A]] =
+    fromIteratorRender("NonEmptyList", _.toList.iterator)
+
+}
+
+trait MidPriorityRender extends LowPriorityRender {
+
+  implicit def renderIterable[A: Render, C[_]](implicit ev: C[A] => Iterable[A]): Render[C[A]] =
+    fromIteratorRender[A, C]("IterableLike", m => ev(m).iterator)
+
+  protected def fromIteratorRender[A: Render, C[_]](name: String, toIterator: C[A] => Iterator[A]): Render[C[A]] =
+    (m: C[A]) => toIterator(m).map(Render[A].render).mkString(s"$name(", ", ", ")")
+
 }
 
 trait LowPriorityRender {

--- a/docs/README.md
+++ b/docs/README.md
@@ -555,8 +555,6 @@ case class ApiConfig(uri: String, @hidden apiKey: String, @length(2) environment
 Example:
 
 ```scala mdoc
-import cats.instances.list.catsStdShowForList
-import cats.instances.string.catsStdShowForString
 import io.odin.syntax._
 import io.odin.extras.derivation._
 import io.odin.extras.derivation.render._

--- a/docs/README.md
+++ b/docs/README.md
@@ -461,7 +461,7 @@ consoleLogger[IO]()
 
 ## Extras
 
-The `odin-extras` module provides additional loggers: ConditionalLogger, etc.
+The `odin-extras` module provides additional functionality: ConditionalLogger, Render derivation, etc.
 
 - Add following dependency to your build:
 
@@ -515,6 +515,62 @@ val service = new UserService[IO](consoleLogger[IO](minLevel = Level.Info))
 
 service.findAndVerify("good-user").attempt.unsafeRunSync()
 service.findAndVerify("bad-user").attempt.unsafeRunSync()
+```
+
+## Extras. Derivation
+
+`io.oden.extras.derivation.render` provides a Magnolia-based derivation of the `Render` type class.
+
+The derivation can be configured via annotations: 
+* @rendered(includeMemberName = false)
+
+The member names will be omitted:
+
+```scala
+@rendered(includeMemberName = false)
+case class ApiConfig(uri: String, apiKey: String)
+```
+
+* @hidden
+
+Excludes an annotated member from the output:
+```scala
+case class ApiConfig(uri: String, @hidden apiKey: String)
+```
+
+* @secret
+
+Replaces the value of an annotated member with `<secret>` :
+```scala
+case class ApiConfig(uri: String, @secret apiKey: String)
+```
+
+* @length
+
+Shows only first N elements of the iterable. Works exclusively with subtypes of `Iterable`:
+```scala
+case class ApiConfig(uri: String, @hidden apiKey: String, @length(2) environments: List[String])
+```
+
+Example:
+
+```scala mdoc
+import cats.instances.list.catsStdShowForList
+import cats.instances.string.catsStdShowForString
+import io.odin.syntax._
+import io.odin.extras.derivation._
+import io.odin.extras.derivation.render._
+
+case class ApiConfig(
+  uri: String,
+  @hidden apiKey: String,
+  @secret apiSecret: String,
+  @length(2) environments: List[String]
+)
+
+val config = ApiConfig("https://localhost:8080", "api-key", "api-secret", List("test", "dev", "pre-prod", "prod"))
+
+println(render"API config $config")
 ```
 
 ## SLF4J bridge

--- a/extras/src/main/scala/io/odin/extras/derivation/annotations.scala
+++ b/extras/src/main/scala/io/odin/extras/derivation/annotations.scala
@@ -1,0 +1,11 @@
+package io.odin.extras.derivation
+
+import scala.annotation.Annotation
+
+final case class rendered(includeMemberName: Boolean) extends Annotation
+
+final case class secret() extends Annotation
+
+final case class hidden() extends Annotation
+
+final case class length(max: Int) extends Annotation

--- a/extras/src/main/scala/io/odin/extras/derivation/render.scala
+++ b/extras/src/main/scala/io/odin/extras/derivation/render.scala
@@ -1,0 +1,83 @@
+package io.odin.extras.derivation
+
+import io.odin.meta.Render
+import magnolia.{CaseClass, Magnolia, Param, SealedTrait}
+
+object render {
+
+  type Typeclass[A] = Render[A]
+
+  def combine[A](ctx: CaseClass[Typeclass, A]): Typeclass[A] = value => {
+    if (ctx.isValueClass) {
+      ctx.parameters.headOption.fold("")(param => param.typeclass.render(param.dereference(value)))
+    } else {
+      val includeMemberNames = RenderUtils.includeMemberNames(ctx)
+
+      val params = ctx.parameters
+        .filterNot(RenderUtils.isHidden)
+        .collect {
+          case param if RenderUtils.isSecret(param) =>
+            RenderUtils.renderParam(param.label, RenderUtils.SecretPlaceholder, includeMemberNames)
+
+          case RenderUtils.hasLengthLimit(param, limit) =>
+            RenderUtils.renderWithLimit(param, value, limit, includeMemberNames)
+
+          case p =>
+            RenderUtils.renderParam(p.label, p.typeclass.render(p.dereference(value)), includeMemberNames)
+        }
+
+      s"${ctx.typeName.short}(${params.mkString(", ")})"
+    }
+  }
+
+  def dispatch[A](ctx: SealedTrait[Typeclass, A]): Typeclass[A] = value => {
+    ctx.dispatch(value)(sub => sub.typeclass.render(sub.cast(value)))
+  }
+
+  def instance[A]: Typeclass[A] = macro Magnolia.gen[A]
+
+  implicit def derive[A]: Typeclass[A] = macro Magnolia.gen[A]
+
+}
+
+private object RenderUtils {
+
+  val SecretPlaceholder = "<secret>"
+
+  @inline def includeMemberNames[A](ctx: CaseClass[Render, A]): Boolean =
+    ctx.annotations
+      .collectFirst {
+        case rendered(v) => v
+      }
+      .getOrElse(true)
+
+  @inline def isSecret[A](param: Param[Render, A]): Boolean =
+    param.annotations.contains(secret())
+
+  @inline def isHidden[A](param: Param[Render, A]): Boolean =
+    param.annotations.contains(hidden())
+
+  @inline def renderParam(label: String, value: String, includeMemberName: Boolean): String =
+    if (includeMemberName) s"$label = $value" else value
+
+  def renderWithLimit[A](param: Param[Render, A], value: A, limit: Int, includeMemberNames: Boolean): String =
+    param.dereference(value) match {
+      case c: Iterable[_] =>
+        val diff = c.iterator.length - limit
+        val suffix = if (diff > 0) s"($diff more)" else ""
+        val value = param.typeclass.render(c.take(limit).asInstanceOf[param.PType]) + suffix
+
+        renderParam(param.label, value, includeMemberNames)
+
+      case other =>
+        renderParam(param.label, param.typeclass.render(other), includeMemberNames)
+    }
+
+  object hasLengthLimit {
+    def unapply[A](arg: Param[Render, A]): Option[(Param[Render, A], Int)] =
+      arg.annotations.collectFirst {
+        case length(limit) => (arg, limit)
+      }
+  }
+
+}

--- a/extras/src/main/scala/io/odin/extras/derivation/render.scala
+++ b/extras/src/main/scala/io/odin/extras/derivation/render.scala
@@ -34,8 +34,35 @@ object render {
     ctx.dispatch(value)(sub => sub.typeclass.render(sub.cast(value)))
   }
 
+  /**
+    * Creates an instance for a concrete type. Does not generate instances for underlying types.
+    *
+    * Example:
+    * {{{
+    *   import io.odin.extras.derivation.render
+    *
+    *   case class A(field: String)
+    *   case class B(field: A)
+    *
+    *   val instanceA: Render[A] = render.instance[A] // compiles
+    *   val instanceB: Render[B] = render.instance[B] // does not compile
+    * }}}
+    */
   def instance[A]: Typeclass[A] = macro Magnolia.gen[A]
 
+  /**
+    * Creates an instance for a concrete type. Recursively generate instances for underlying types.
+    *
+    * Example:
+    * {{{
+    *   import io.odin.extras.derivation.render
+    *
+    *   case class A(field: String)
+    *   case class B(field: A)
+    *
+    *   val instanceB: Render[B] = render.render[B]
+    * }}}
+    */
   implicit def derive[A]: Typeclass[A] = macro Magnolia.gen[A]
 
 }

--- a/extras/src/test/scala/io/odin/extras/derivation/RenderDerivationSpec.scala
+++ b/extras/src/test/scala/io/odin/extras/derivation/RenderDerivationSpec.scala
@@ -1,0 +1,109 @@
+package io.odin.extras.derivation
+
+import cats.instances.list.catsStdShowForList
+import cats.instances.long.catsStdShowForLong
+import cats.instances.string.catsStdShowForString
+import cats.instances.int.catsStdShowForInt
+import io.odin.OdinSpec
+import io.odin.extras.derivation.RenderDerivationSpec._
+import io.odin.extras.derivation.render._
+import io.odin.meta.Render
+import org.scalacheck.{Arbitrary, Gen}
+
+class RenderDerivationSpec extends OdinSpec {
+
+  it should "hide fields with @hidden annotation" in {
+    val instance = WithHidden("my-field", 42)
+    val expected = "WithHidden(field = my-field)"
+
+    Render[WithHidden[String, Int]].render(instance) shouldBe expected
+  }
+
+  it should "mask fields with @secret annotation" in {
+    val instance = WithSecret("my-field", "api-key")
+    val expected = "WithSecret(field = my-field, secret = <secret>)"
+
+    Render[WithSecret[String, String]].render(instance) shouldBe expected
+  }
+
+  it should "show limited number of elements with @length annotation" in {
+    val instance = WithLengthLimit("my-field", List(1, 2, 3, 4, 5))
+    val expected = "WithLengthLimit(field = my-field, limited = List(1, 2, 3)(2 more))"
+
+    Render[WithLengthLimit[String, List[Int]]].render(instance) shouldBe expected
+  }
+
+  it should "ignore @length annotation when annotated type is not a subtype of Iterable" in {
+    val instance = WithLengthLimit("my-field", "api-key")
+    val expected = "WithLengthLimit(field = my-field, limited = api-key)"
+
+    Render[WithLengthLimit[String, String]].render(instance) shouldBe expected
+  }
+
+  it should "derive a type class respecting annotations" in forAll { bar: Bar =>
+    def renderFoo(foo: Foo): String =
+      s"Foo(GenericClass(field = ${foo.field.field.value}, secret = <secret>, lengthLimited = ${foo.field.lengthLimited}))"
+
+    val diff = bar.genericClass.lengthLimited.length - LengthLimit
+    val suffix = if (diff > 0) s"($diff more)" else ""
+
+    val lengthLimited = Render[List[String]].render(bar.genericClass.lengthLimited.map(renderFoo).take(LengthLimit))
+
+    val generic =
+      s"GenericClass(field = ${bar.genericClass.field}, secret = <secret>, lengthLimited = $lengthLimited$suffix)"
+
+    val expected = s"Bar(genericClass = $generic)"
+
+    Render[Bar].render(bar) shouldBe expected
+  }
+
+  val valueClassGen: Gen[ValueClass] =
+    for {
+      int <- Gen.posNum[Int]
+    } yield ValueClass(int)
+
+  val fooGen: Gen[Foo] =
+    for {
+      field <- valueClassGen
+      hidden <- Gen.negNum[Long]
+      secret <- nonEmptyStringGen
+      lengthLimited <- nonEmptyStringGen
+    } yield Foo(GenericClass(field, hidden, secret, lengthLimited))
+
+  val barGen: Gen[Bar] =
+    for {
+      field <- nonEmptyStringGen
+      hidden <- valueClassGen
+      secret <- Gen.listOf(nonEmptyStringGen)
+      lengthLimited <- Gen.listOf(fooGen)
+    } yield Bar(GenericClass(field, hidden, secret, lengthLimited))
+
+  implicit val barArbitrary: Arbitrary[Bar] = Arbitrary(barGen)
+
+}
+
+object RenderDerivationSpec {
+
+  val LengthLimit: Int = 3
+
+  final case class WithHidden[A, B](field: A, @hidden hidden: B)
+
+  final case class WithSecret[A, B](field: A, @secret secret: B)
+
+  final case class WithLengthLimit[A, B](field: A, @length(LengthLimit) limited: B)
+
+  final case class GenericClass[A, B, C, D](
+      field: A,
+      @hidden hidden: B,
+      @secret secret: C,
+      @length(LengthLimit) lengthLimited: D
+  )
+
+  final case class ValueClass(value: Int) extends AnyVal
+
+  @rendered(includeMemberName = false)
+  final case class Foo(field: GenericClass[ValueClass, Long, String, String])
+
+  final case class Bar(genericClass: GenericClass[String, ValueClass, List[String], List[Foo]])
+
+}


### PR DESCRIPTION
This PR closes https://github.com/valskalla/odin/issues/70.

The only thing that bothers me is the necessity of explicit imports of `cats.Show` for primitives.
Since `Render` does not provide instances for primitives, the `cats.instances.{primitive}._` import is mandatory for derivation.

Should we provide default instances for the following types: Byte, Int, Short, Long, Double, Float, Boolean, UUID? Basically, it will be `Render.fromToString`. 
And the polymorphic default instances for `List` and `Option`.

In this case, magnolia will be able to derive a type class almost for every case class without additional imports.