### PR TITLE
Add ToThrowable type class. Deprecate some log methods

### DIFF
--- a/benchmarks/src/main/scala/io/odin/Benchmarks.scala
+++ b/benchmarks/src/main/scala/io/odin/Benchmarks.scala
@@ -67,7 +67,7 @@ class DefaultLoggerBenchmarks extends OdinBenchmarks {
   def msgAndCtx(): Unit = defaultLogger.info(message, context).unsafeRunSync()
 
   @Benchmark
-  def msgCtxThrowable(): Unit = defaultLogger.info(message, context, throwable).unsafeRunSync()
+  def msgCtxThrowable(): Unit = defaultLogger.info[String, Throwable](message, context, throwable).unsafeRunSync()
 }
 
 @State(Scope.Benchmark)
@@ -89,7 +89,7 @@ class FileLoggerBenchmarks extends OdinBenchmarks {
   @Benchmark
   @OperationsPerInvocation(1000)
   def msgCtxThrowable(): Unit =
-    for (_ <- 1 to 1000) logger.info(message, context, throwable).unsafeRunSync()
+    for (_ <- 1 to 1000) logger.info[String, Throwable](message, context, throwable).unsafeRunSync()
 
   @TearDown
   def tearDown(): Unit = {
@@ -191,7 +191,7 @@ class AsyncLoggerBenchmark extends OdinBenchmarks {
   @Benchmark
   @OperationsPerInvocation(1000)
   def msgCtxThrowable(): Unit =
-    for (_ <- 1 to 1000) asyncLogger.info(message, context, throwable).unsafeRunSync()
+    for (_ <- 1 to 1000) asyncLogger.info[String, Throwable](message, context, throwable).unsafeRunSync()
 
   @TearDown
   def tearDown(): Unit = {

--- a/core/src/main/scala/io/odin/Logger.scala
+++ b/core/src/main/scala/io/odin/Logger.scala
@@ -3,7 +3,7 @@ package io.odin
 import cats.kernel.LowerBounded
 import cats.syntax.all._
 import cats.{~>, Applicative, Monoid}
-import io.odin.meta.{Position, Render}
+import io.odin.meta.{Position, Render, ToThrowable}
 
 trait Logger[F[_]] {
   def minLevel: Level
@@ -16,58 +16,109 @@ trait Logger[F[_]] {
 
   def trace[M](msg: => M)(implicit render: Render[M], position: Position): F[Unit]
 
+  @deprecated("Use `trace[M, E](msg: => M, e: E)` instead", "0.5.1")
   def trace[M](msg: => M, t: Throwable)(implicit render: Render[M], position: Position): F[Unit]
+
+  def trace[M, E](msg: => M, e: E)(implicit render: Render[M], tt: ToThrowable[E], position: Position): F[Unit]
 
   def trace[M](msg: => M, ctx: Map[String, String])(implicit render: Render[M], position: Position): F[Unit]
 
+  @deprecated("Use `trace[M, E](msg: => M, ctx: Map[String, String], e: E)` instead", "0.5.1")
   def trace[M](msg: => M, ctx: Map[String, String], t: Throwable)(
       implicit render: Render[M],
       position: Position
   ): F[Unit]
 
+  def trace[M, E](msg: => M, ctx: Map[String, String], e: E)(
+      implicit render: Render[M],
+      tt: ToThrowable[E],
+      position: Position
+  ): F[Unit]
+
   def debug[M](msg: => M)(implicit render: Render[M], position: Position): F[Unit]
 
+  @deprecated("Use `debug[M, E](msg: => M, e: E)` instead", "0.5.1")
   def debug[M](msg: => M, t: Throwable)(implicit render: Render[M], position: Position): F[Unit]
+
+  def debug[M, E](msg: => M, e: E)(implicit render: Render[M], tt: ToThrowable[E], position: Position): F[Unit]
 
   def debug[M](msg: => M, ctx: Map[String, String])(implicit render: Render[M], position: Position): F[Unit]
 
+  @deprecated("Use `debug[M, E](msg: => M, ctx: Map[String, String], e: E)` instead", "0.5.1")
   def debug[M](msg: => M, ctx: Map[String, String], t: Throwable)(
       implicit render: Render[M],
       position: Position
   ): F[Unit]
 
+  def debug[M, E](msg: => M, ctx: Map[String, String], e: E)(
+      implicit render: Render[M],
+      tt: ToThrowable[E],
+      position: Position
+  ): F[Unit]
+
   def info[M](msg: => M)(implicit render: Render[M], position: Position): F[Unit]
 
+  @deprecated("Use `info[M, E](msg: => M, e: E)` instead", "0.5.1")
   def info[M](msg: => M, t: Throwable)(implicit render: Render[M], position: Position): F[Unit]
+
+  def info[M, E](msg: => M, e: E)(implicit render: Render[M], tt: ToThrowable[E], position: Position): F[Unit]
 
   def info[M](msg: => M, ctx: Map[String, String])(implicit render: Render[M], position: Position): F[Unit]
 
+  @deprecated("Use `info[M, E](msg: => M, ctx: Map[String, String], e: E)` instead", "0.5.1")
   def info[M](msg: => M, ctx: Map[String, String], t: Throwable)(
       implicit render: Render[M],
       position: Position
   ): F[Unit]
 
+  def info[M, E](msg: => M, ctx: Map[String, String], e: E)(
+      implicit render: Render[M],
+      tt: ToThrowable[E],
+      position: Position
+  ): F[Unit]
+
   def warn[M](msg: => M)(implicit render: Render[M], position: Position): F[Unit]
 
+  @deprecated("Use `warn[M, E](msg: => M, e: E)` instead", "0.5.1")
   def warn[M](msg: => M, t: Throwable)(implicit render: Render[M], position: Position): F[Unit]
+
+  def warn[M, E](msg: => M, e: E)(implicit render: Render[M], tt: ToThrowable[E], position: Position): F[Unit]
 
   def warn[M](msg: => M, ctx: Map[String, String])(implicit render: Render[M], position: Position): F[Unit]
 
+  @deprecated("Use `warn[M, E](msg: => M, ctx: Map[String, String], e: E)` instead", "0.5.1")
   def warn[M](msg: => M, ctx: Map[String, String], t: Throwable)(
       implicit render: Render[M],
       position: Position
   ): F[Unit]
 
+  def warn[M, E](msg: => M, ctx: Map[String, String], e: E)(
+      implicit render: Render[M],
+      tt: ToThrowable[E],
+      position: Position
+  ): F[Unit]
+
   def error[M](msg: => M)(implicit render: Render[M], position: Position): F[Unit]
 
+  @deprecated("Use `error[M, E](msg: => M, e: E)` instead", "0.5.1")
   def error[M](msg: => M, t: Throwable)(implicit render: Render[M], position: Position): F[Unit]
+
+  def error[M, E](msg: => M, e: E)(implicit render: Render[M], tt: ToThrowable[E], position: Position): F[Unit]
 
   def error[M](msg: => M, ctx: Map[String, String])(implicit render: Render[M], position: Position): F[Unit]
 
+  @deprecated("Use `error[M, E](msg: => M, ctx: Map[String, String], e: E)` instead", "0.5.1")
   def error[M](msg: => M, ctx: Map[String, String], t: Throwable)(
       implicit render: Render[M],
       position: Position
   ): F[Unit]
+
+  def error[M, E](msg: => M, ctx: Map[String, String], e: E)(
+      implicit render: Render[M],
+      tt: ToThrowable[E],
+      position: Position
+  ): F[Unit]
+
 }
 
 object Logger extends Noop with LoggerInstances {
@@ -87,7 +138,10 @@ object Logger extends Noop with LoggerInstances {
       def trace[M](msg: => M)(implicit render: Render[M], position: Position): G[Unit] = f(logger.trace(msg))
 
       def trace[M](msg: => M, t: Throwable)(implicit render: Render[M], position: Position): G[Unit] =
-        f(logger.trace(msg, t))
+        trace[M, Throwable](msg, t)
+
+      def trace[M, E](msg: => M, e: E)(implicit render: Render[M], tt: ToThrowable[E], position: Position): G[Unit] =
+        f(logger.trace(msg, e))
 
       def trace[M](msg: => M, ctx: Map[String, String])(implicit render: Render[M], position: Position): G[Unit] =
         f(logger.trace(msg, ctx))
@@ -96,13 +150,23 @@ object Logger extends Noop with LoggerInstances {
           implicit render: Render[M],
           position: Position
       ): G[Unit] =
-        f(logger.trace(msg, ctx, t))
+        trace[M, Throwable](msg, ctx, t)
+
+      def trace[M, E](msg: => M, ctx: Map[String, String], e: E)(
+          implicit render: Render[M],
+          tt: ToThrowable[E],
+          position: Position
+      ): G[Unit] =
+        f(logger.trace(msg, ctx, e))
 
       def debug[M](msg: => M)(implicit render: Render[M], position: Position): G[Unit] =
         f(logger.debug(msg))
 
       def debug[M](msg: => M, t: Throwable)(implicit render: Render[M], position: Position): G[Unit] =
-        f(logger.debug(msg, t))
+        debug[M, Throwable](msg, t)
+
+      def debug[M, E](msg: => M, e: E)(implicit render: Render[M], tt: ToThrowable[E], position: Position): G[Unit] =
+        f(logger.debug(msg, e))
 
       def debug[M](msg: => M, ctx: Map[String, String])(implicit render: Render[M], position: Position): G[Unit] =
         f(logger.debug(msg, ctx))
@@ -111,13 +175,23 @@ object Logger extends Noop with LoggerInstances {
           implicit render: Render[M],
           position: Position
       ): G[Unit] =
-        f(logger.debug(msg, ctx, t))
+        debug[M, Throwable](msg, ctx, t)
+
+      def debug[M, E](msg: => M, ctx: Map[String, String], e: E)(
+          implicit render: Render[M],
+          tt: ToThrowable[E],
+          position: Position
+      ): G[Unit] =
+        f(logger.debug(msg, ctx, e))
 
       def info[M](msg: => M)(implicit render: Render[M], position: Position): G[Unit] =
         f(logger.info(msg))
 
       def info[M](msg: => M, t: Throwable)(implicit render: Render[M], position: Position): G[Unit] =
-        f(logger.info(msg, t))
+        info[M, Throwable](msg, t)
+
+      def info[M, E](msg: => M, e: E)(implicit render: Render[M], tt: ToThrowable[E], position: Position): G[Unit] =
+        f(logger.info(msg, e))
 
       def info[M](msg: => M, ctx: Map[String, String])(implicit render: Render[M], position: Position): G[Unit] =
         f(logger.info(msg, ctx))
@@ -126,13 +200,23 @@ object Logger extends Noop with LoggerInstances {
           implicit render: Render[M],
           position: Position
       ): G[Unit] =
-        f(logger.info(msg, ctx, t))
+        info[M, Throwable](msg, ctx, t)
+
+      def info[M, E](msg: => M, ctx: Map[String, String], e: E)(
+          implicit render: Render[M],
+          tt: ToThrowable[E],
+          position: Position
+      ): G[Unit] =
+        f(logger.info(msg, ctx, e))
 
       def warn[M](msg: => M)(implicit render: Render[M], position: Position): G[Unit] =
         f(logger.warn(msg))
 
       def warn[M](msg: => M, t: Throwable)(implicit render: Render[M], position: Position): G[Unit] =
-        f(logger.warn(msg, t))
+        warn[M, Throwable](msg, t)
+
+      def warn[M, E](msg: => M, e: E)(implicit render: Render[M], tt: ToThrowable[E], position: Position): G[Unit] =
+        f(logger.warn(msg, e))
 
       def warn[M](msg: => M, ctx: Map[String, String])(implicit render: Render[M], position: Position): G[Unit] =
         f(logger.warn(msg, ctx))
@@ -141,13 +225,23 @@ object Logger extends Noop with LoggerInstances {
           implicit render: Render[M],
           position: Position
       ): G[Unit] =
-        f(logger.warn(msg, ctx, t))
+        warn[M, Throwable](msg, ctx, t)
+
+      def warn[M, E](msg: => M, ctx: Map[String, String], e: E)(
+          implicit render: Render[M],
+          tt: ToThrowable[E],
+          position: Position
+      ): G[Unit] =
+        f(logger.warn(msg, ctx, e))
 
       def error[M](msg: => M)(implicit render: Render[M], position: Position): G[Unit] =
         f(logger.error(msg))
 
       def error[M](msg: => M, t: Throwable)(implicit render: Render[M], position: Position): G[Unit] =
-        f(logger.error(msg, t))
+        error[M, Throwable](msg, t)
+
+      def error[M, E](msg: => M, e: E)(implicit render: Render[M], tt: ToThrowable[E], position: Position): G[Unit] =
+        f(logger.error(msg, e))
 
       def error[M](msg: => M, ctx: Map[String, String])(implicit render: Render[M], position: Position): G[Unit] =
         f(logger.error(msg, ctx))
@@ -156,7 +250,14 @@ object Logger extends Noop with LoggerInstances {
           implicit render: Render[M],
           position: Position
       ): G[Unit] =
-        f(logger.error(msg, ctx, t))
+        error[M, Throwable](msg, ctx, t)
+
+      def error[M, E](msg: => M, ctx: Map[String, String], e: E)(
+          implicit render: Render[M],
+          tt: ToThrowable[E],
+          position: Position
+      ): G[Unit] =
+        f(logger.error(msg, ctx, e))
     }
   }
 }
@@ -182,6 +283,8 @@ private[odin] class NoopLogger[F[_]](implicit F: Applicative[F]) extends Logger[
 
   def trace[M](msg: => M, t: Throwable)(implicit render: Render[M], position: Position): F[Unit] = F.unit
 
+  def trace[M, E](msg: => M, e: E)(implicit render: Render[M], tt: ToThrowable[E], position: Position): F[Unit] = F.unit
+
   def trace[M](msg: => M, ctx: Map[String, String])(implicit render: Render[M], position: Position): F[Unit] = F.unit
 
   def trace[M](msg: => M, ctx: Map[String, String], t: Throwable)(
@@ -189,9 +292,17 @@ private[odin] class NoopLogger[F[_]](implicit F: Applicative[F]) extends Logger[
       position: Position
   ): F[Unit] = F.unit
 
+  def trace[M, E](msg: => M, ctx: Map[String, String], e: E)(
+      implicit render: Render[M],
+      tt: ToThrowable[E],
+      position: Position
+  ): F[Unit] = F.unit
+
   def debug[M](msg: => M)(implicit render: Render[M], position: Position): F[Unit] = F.unit
 
   def debug[M](msg: => M, t: Throwable)(implicit render: Render[M], position: Position): F[Unit] = F.unit
+
+  def debug[M, E](msg: => M, e: E)(implicit render: Render[M], tt: ToThrowable[E], position: Position): F[Unit] = F.unit
 
   def debug[M](msg: => M, ctx: Map[String, String])(implicit render: Render[M], position: Position): F[Unit] = F.unit
 
@@ -200,9 +311,17 @@ private[odin] class NoopLogger[F[_]](implicit F: Applicative[F]) extends Logger[
       position: Position
   ): F[Unit] = F.unit
 
+  def debug[M, E](msg: => M, ctx: Map[String, String], e: E)(
+      implicit render: Render[M],
+      tt: ToThrowable[E],
+      position: Position
+  ): F[Unit] = F.unit
+
   def info[M](msg: => M)(implicit render: Render[M], position: Position): F[Unit] = F.unit
 
   def info[M](msg: => M, t: Throwable)(implicit render: Render[M], position: Position): F[Unit] = F.unit
+
+  def info[M, E](msg: => M, e: E)(implicit render: Render[M], tt: ToThrowable[E], position: Position): F[Unit] = F.unit
 
   def info[M](msg: => M, ctx: Map[String, String])(implicit render: Render[M], position: Position): F[Unit] = F.unit
 
@@ -211,9 +330,17 @@ private[odin] class NoopLogger[F[_]](implicit F: Applicative[F]) extends Logger[
       position: Position
   ): F[Unit] = F.unit
 
+  def info[M, E](msg: => M, ctx: Map[String, String], e: E)(
+      implicit render: Render[M],
+      tt: ToThrowable[E],
+      position: Position
+  ): F[Unit] = F.unit
+
   def warn[M](msg: => M)(implicit render: Render[M], position: Position): F[Unit] = F.unit
 
   def warn[M](msg: => M, t: Throwable)(implicit render: Render[M], position: Position): F[Unit] = F.unit
+
+  def warn[M, E](msg: => M, e: E)(implicit render: Render[M], tt: ToThrowable[E], position: Position): F[Unit] = F.unit
 
   def warn[M](msg: => M, ctx: Map[String, String])(implicit render: Render[M], position: Position): F[Unit] = F.unit
 
@@ -222,14 +349,28 @@ private[odin] class NoopLogger[F[_]](implicit F: Applicative[F]) extends Logger[
       position: Position
   ): F[Unit] = F.unit
 
+  def warn[M, E](msg: => M, ctx: Map[String, String], e: E)(
+      implicit render: Render[M],
+      tt: ToThrowable[E],
+      position: Position
+  ): F[Unit] = F.unit
+
   def error[M](msg: => M)(implicit render: Render[M], position: Position): F[Unit] = F.unit
 
   def error[M](msg: => M, t: Throwable)(implicit render: Render[M], position: Position): F[Unit] = F.unit
+
+  def error[M, E](msg: => M, e: E)(implicit render: Render[M], tt: ToThrowable[E], position: Position): F[Unit] = F.unit
 
   def error[M](msg: => M, ctx: Map[String, String])(implicit render: Render[M], position: Position): F[Unit] = F.unit
 
   def error[M](msg: => M, ctx: Map[String, String], t: Throwable)(
       implicit render: Render[M],
+      position: Position
+  ): F[Unit] = F.unit
+
+  def error[M, E](msg: => M, ctx: Map[String, String], e: E)(
+      implicit render: Render[M],
+      tt: ToThrowable[E],
       position: Position
   ): F[Unit] = F.unit
 }
@@ -251,7 +392,10 @@ private[odin] class MonoidLogger[F[_]: Applicative] extends Monoid[Logger[F]] {
       x.trace(msg) *> y.trace(msg)
 
     def trace[M](msg: => M, t: Throwable)(implicit render: Render[M], position: Position): F[Unit] =
-      x.trace(msg, t) *> y.trace(msg, t)
+      trace[M, Throwable](msg, t)
+
+    def trace[M, E](msg: => M, e: E)(implicit render: Render[M], tt: ToThrowable[E], position: Position): F[Unit] =
+      x.trace(msg, e) *> y.trace(msg, e)
 
     def trace[M](msg: => M, ctx: Map[String, String])(implicit render: Render[M], position: Position): F[Unit] =
       x.trace(msg, ctx) *> y.trace(msg, ctx)
@@ -260,13 +404,23 @@ private[odin] class MonoidLogger[F[_]: Applicative] extends Monoid[Logger[F]] {
         implicit render: Render[M],
         position: Position
     ): F[Unit] =
-      x.trace(msg, ctx, t) *> y.trace(msg, ctx, t)
+      trace[M, Throwable](msg, ctx, t)
+
+    def trace[M, E](msg: => M, ctx: Map[String, String], e: E)(
+        implicit render: Render[M],
+        tt: ToThrowable[E],
+        position: Position
+    ): F[Unit] =
+      x.trace(msg, ctx, e) *> y.trace(msg, ctx, e)
 
     def debug[M](msg: => M)(implicit render: Render[M], position: Position): F[Unit] =
       x.debug(msg) *> y.debug(msg)
 
     def debug[M](msg: => M, t: Throwable)(implicit render: Render[M], position: Position): F[Unit] =
-      x.debug(msg, t) *> y.debug(msg, t)
+      debug[M, Throwable](msg, t)
+
+    def debug[M, E](msg: => M, e: E)(implicit render: Render[M], tt: ToThrowable[E], position: Position): F[Unit] =
+      x.debug(msg, e) *> y.debug(msg, e)
 
     def debug[M](msg: => M, ctx: Map[String, String])(implicit render: Render[M], position: Position): F[Unit] =
       x.debug(msg, ctx) *> y.debug(msg, ctx)
@@ -275,13 +429,23 @@ private[odin] class MonoidLogger[F[_]: Applicative] extends Monoid[Logger[F]] {
         implicit render: Render[M],
         position: Position
     ): F[Unit] =
-      x.debug(msg, ctx, t) *> y.debug(msg, ctx, t)
+      debug[M, Throwable](msg, ctx, t)
+
+    def debug[M, E](msg: => M, ctx: Map[String, String], e: E)(
+        implicit render: Render[M],
+        tt: ToThrowable[E],
+        position: Position
+    ): F[Unit] =
+      x.debug(msg, ctx, e) *> y.debug(msg, ctx, e)
 
     def info[M](msg: => M)(implicit render: Render[M], position: Position): F[Unit] =
       x.info(msg) *> y.info(msg)
 
     def info[M](msg: => M, t: Throwable)(implicit render: Render[M], position: Position): F[Unit] =
-      x.info(msg, t) *> y.info(msg, t)
+      info[M, Throwable](msg, t)
+
+    def info[M, E](msg: => M, e: E)(implicit render: Render[M], tt: ToThrowable[E], position: Position): F[Unit] =
+      x.info(msg, e) *> y.info(msg, e)
 
     def info[M](msg: => M, ctx: Map[String, String])(implicit render: Render[M], position: Position): F[Unit] =
       x.info(msg, ctx) *> y.info(msg, ctx)
@@ -290,13 +454,23 @@ private[odin] class MonoidLogger[F[_]: Applicative] extends Monoid[Logger[F]] {
         implicit render: Render[M],
         position: Position
     ): F[Unit] =
-      x.info(msg, ctx, t) *> y.info(msg, ctx, t)
+      info[M, Throwable](msg, ctx, t)
+
+    def info[M, E](msg: => M, ctx: Map[String, String], e: E)(
+        implicit render: Render[M],
+        tt: ToThrowable[E],
+        position: Position
+    ): F[Unit] =
+      x.info(msg, ctx, e) *> y.info(msg, ctx, e)
 
     def warn[M](msg: => M)(implicit render: Render[M], position: Position): F[Unit] =
       x.warn(msg) *> y.warn(msg)
 
     def warn[M](msg: => M, t: Throwable)(implicit render: Render[M], position: Position): F[Unit] =
-      x.warn(msg, t) *> y.warn(msg, t)
+      warn[M, Throwable](msg, t)
+
+    def warn[M, E](msg: => M, e: E)(implicit render: Render[M], tt: ToThrowable[E], position: Position): F[Unit] =
+      x.warn(msg, e) *> y.warn(msg, e)
 
     def warn[M](msg: => M, ctx: Map[String, String])(implicit render: Render[M], position: Position): F[Unit] =
       x.warn(msg, ctx) *> y.warn(msg, ctx)
@@ -305,13 +479,23 @@ private[odin] class MonoidLogger[F[_]: Applicative] extends Monoid[Logger[F]] {
         implicit render: Render[M],
         position: Position
     ): F[Unit] =
-      x.warn(msg, ctx, t) *> y.warn(msg, ctx, t)
+      warn[M, Throwable](msg, ctx, t)
+
+    def warn[M, E](msg: => M, ctx: Map[String, String], e: E)(
+        implicit render: Render[M],
+        tt: ToThrowable[E],
+        position: Position
+    ): F[Unit] =
+      x.warn(msg, ctx, e) *> y.warn(msg, ctx, e)
 
     def error[M](msg: => M)(implicit render: Render[M], position: Position): F[Unit] =
       x.error(msg) *> y.error(msg)
 
     def error[M](msg: => M, t: Throwable)(implicit render: Render[M], position: Position): F[Unit] =
-      x.error(msg, t) *> y.error(msg, t)
+      error[M, Throwable](msg, t)
+
+    def error[M, E](msg: => M, e: E)(implicit render: Render[M], tt: ToThrowable[E], position: Position): F[Unit] =
+      x.error(msg, e) *> y.error(msg, e)
 
     def error[M](msg: => M, ctx: Map[String, String])(implicit render: Render[M], position: Position): F[Unit] =
       x.error(msg, ctx) *> y.error(msg, ctx)
@@ -320,6 +504,13 @@ private[odin] class MonoidLogger[F[_]: Applicative] extends Monoid[Logger[F]] {
         implicit render: Render[M],
         position: Position
     ): F[Unit] =
-      x.error(msg, ctx, t) *> y.error(msg, ctx, t)
+      error[M, Throwable](msg, ctx, t)
+
+    def error[M, E](msg: => M, ctx: Map[String, String], e: E)(
+        implicit render: Render[M],
+        tt: ToThrowable[E],
+        position: Position
+    ): F[Unit] =
+      x.error(msg, ctx, e) *> y.error(msg, ctx, e)
   }
 }

--- a/core/src/main/scala/io/odin/loggers/DefaultLogger.scala
+++ b/core/src/main/scala/io/odin/loggers/DefaultLogger.scala
@@ -6,7 +6,7 @@ import cats.{Eval, Monad}
 import cats.effect.Timer
 import cats.instances.all._
 import cats.syntax.all._
-import io.odin.meta.{Position, Render}
+import io.odin.meta.{Position, Render, ToThrowable}
 import io.odin.{Level, Logger, LoggerMessage}
 
 /**
@@ -52,8 +52,11 @@ abstract class DefaultLogger[F[_]](val minLevel: Level = Level.Trace)(implicit t
     }
 
   def trace[M](msg: => M, t: Throwable)(implicit render: Render[M], position: Position): F[Unit] =
+    trace[M, Throwable](msg, t)
+
+  def trace[M, E](msg: => M, e: E)(implicit render: Render[M], tt: ToThrowable[E], position: Position): F[Unit] =
     F.whenA(minLevel <= Level.Trace) {
-      log(Level.Trace, msg, t = Some(t))
+      log(Level.Trace, msg, t = Some(tt.throwable(e)))
     }
 
   def trace[M](msg: => M, ctx: Map[String, String])(implicit render: Render[M], position: Position): F[Unit] =
@@ -65,8 +68,15 @@ abstract class DefaultLogger[F[_]](val minLevel: Level = Level.Trace)(implicit t
       implicit render: Render[M],
       position: Position
   ): F[Unit] =
+    trace[M, Throwable](msg, ctx, t)
+
+  def trace[M, E](msg: => M, ctx: Map[String, String], e: E)(
+      implicit render: Render[M],
+      tt: ToThrowable[E],
+      position: Position
+  ): F[Unit] =
     F.whenA(minLevel <= Level.Trace) {
-      log(Level.Trace, msg, ctx, Some(t))
+      log(Level.Trace, msg, ctx, Some(tt.throwable(e)))
     }
 
   def debug[M](msg: => M)(implicit render: Render[M], position: Position): F[Unit] =
@@ -75,8 +85,11 @@ abstract class DefaultLogger[F[_]](val minLevel: Level = Level.Trace)(implicit t
     }
 
   def debug[M](msg: => M, t: Throwable)(implicit render: Render[M], position: Position): F[Unit] =
+    debug[M, Throwable](msg, t)
+
+  def debug[M, E](msg: => M, e: E)(implicit render: Render[M], tt: ToThrowable[E], position: Position): F[Unit] =
     F.whenA(minLevel <= Level.Debug) {
-      log(Level.Debug, msg, t = Some(t))
+      log(Level.Debug, msg, t = Some(tt.throwable(e)))
     }
 
   def debug[M](msg: => M, ctx: Map[String, String])(implicit render: Render[M], position: Position): F[Unit] =
@@ -88,8 +101,15 @@ abstract class DefaultLogger[F[_]](val minLevel: Level = Level.Trace)(implicit t
       implicit render: Render[M],
       position: Position
   ): F[Unit] =
+    debug[M, Throwable](msg, ctx, t)
+
+  def debug[M, E](msg: => M, ctx: Map[String, String], e: E)(
+      implicit render: Render[M],
+      tt: ToThrowable[E],
+      position: Position
+  ): F[Unit] =
     F.whenA(minLevel <= Level.Debug) {
-      log(Level.Debug, msg, ctx, Some(t))
+      log(Level.Debug, msg, ctx, Some(tt.throwable(e)))
     }
 
   def info[M](msg: => M)(implicit render: Render[M], position: Position): F[Unit] =
@@ -98,8 +118,11 @@ abstract class DefaultLogger[F[_]](val minLevel: Level = Level.Trace)(implicit t
     }
 
   def info[M](msg: => M, t: Throwable)(implicit render: Render[M], position: Position): F[Unit] =
+    info[M, Throwable](msg, t)
+
+  def info[M, E](msg: => M, e: E)(implicit render: Render[M], tt: ToThrowable[E], position: Position): F[Unit] =
     F.whenA(minLevel <= Level.Info) {
-      log(Level.Info, msg, t = Some(t))
+      log(Level.Info, msg, t = Some(tt.throwable(e)))
     }
 
   def info[M](msg: => M, ctx: Map[String, String])(implicit render: Render[M], position: Position): F[Unit] =
@@ -111,8 +134,15 @@ abstract class DefaultLogger[F[_]](val minLevel: Level = Level.Trace)(implicit t
       implicit render: Render[M],
       position: Position
   ): F[Unit] =
+    info[M, Throwable](msg, ctx, t)
+
+  def info[M, E](msg: => M, ctx: Map[String, String], e: E)(
+      implicit render: Render[M],
+      tt: ToThrowable[E],
+      position: Position
+  ): F[Unit] =
     F.whenA(minLevel <= Level.Info) {
-      log(Level.Info, msg, ctx, Some(t))
+      log(Level.Info, msg, ctx, Some(tt.throwable(e)))
     }
 
   def warn[M](msg: => M)(implicit render: Render[M], position: Position): F[Unit] =
@@ -121,8 +151,11 @@ abstract class DefaultLogger[F[_]](val minLevel: Level = Level.Trace)(implicit t
     }
 
   def warn[M](msg: => M, t: Throwable)(implicit render: Render[M], position: Position): F[Unit] =
+    warn[M, Throwable](msg, t)
+
+  def warn[M, E](msg: => M, e: E)(implicit render: Render[M], tt: ToThrowable[E], position: Position): F[Unit] =
     F.whenA(minLevel <= Level.Warn) {
-      log(Level.Warn, msg, t = Some(t))
+      log(Level.Warn, msg, t = Some(tt.throwable(e)))
     }
 
   def warn[M](msg: => M, ctx: Map[String, String])(implicit render: Render[M], position: Position): F[Unit] =
@@ -134,8 +167,15 @@ abstract class DefaultLogger[F[_]](val minLevel: Level = Level.Trace)(implicit t
       implicit render: Render[M],
       position: Position
   ): F[Unit] =
+    warn[M, Throwable](msg, ctx, t)
+
+  def warn[M, E](msg: => M, ctx: Map[String, String], e: E)(
+      implicit render: Render[M],
+      tt: ToThrowable[E],
+      position: Position
+  ): F[Unit] =
     F.whenA(minLevel <= Level.Warn) {
-      log(Level.Warn, msg, ctx, Some(t))
+      log(Level.Warn, msg, ctx, Some(tt.throwable(e)))
     }
 
   def error[M](msg: => M)(implicit render: Render[M], position: Position): F[Unit] =
@@ -144,8 +184,11 @@ abstract class DefaultLogger[F[_]](val minLevel: Level = Level.Trace)(implicit t
     }
 
   def error[M](msg: => M, t: Throwable)(implicit render: Render[M], position: Position): F[Unit] =
+    error[M, Throwable](msg, t)
+
+  def error[M, E](msg: => M, e: E)(implicit render: Render[M], tt: ToThrowable[E], position: Position): F[Unit] =
     F.whenA(minLevel <= Level.Error) {
-      log(Level.Error, msg, t = Some(t))
+      log(Level.Error, msg, t = Some(tt.throwable(e)))
     }
 
   def error[M](msg: => M, ctx: Map[String, String])(implicit render: Render[M], position: Position): F[Unit] =
@@ -157,7 +200,14 @@ abstract class DefaultLogger[F[_]](val minLevel: Level = Level.Trace)(implicit t
       implicit render: Render[M],
       position: Position
   ): F[Unit] =
+    error[M, Throwable](msg, ctx, t)
+
+  def error[M, E](msg: => M, ctx: Map[String, String], e: E)(
+      implicit render: Render[M],
+      tt: ToThrowable[E],
+      position: Position
+  ): F[Unit] =
     F.whenA(minLevel <= Level.Error) {
-      log(Level.Error, msg, ctx, t = Some(t))
+      log(Level.Error, msg, ctx, Some(tt.throwable(e)))
     }
 }

--- a/core/src/main/scala/io/odin/meta/ToThrowable.scala
+++ b/core/src/main/scala/io/odin/meta/ToThrowable.scala
@@ -1,0 +1,12 @@
+package io.odin.meta
+
+/**
+  * Type class that converts a value of type `E` into Throwable
+  */
+trait ToThrowable[E] {
+  def throwable(e: E): Throwable
+}
+
+object ToThrowable {
+  implicit def toThrowable[E <: Throwable]: ToThrowable[E] = (e: E) => e
+}

--- a/core/src/test/scala/io/odin/EqInstances.scala
+++ b/core/src/test/scala/io/odin/EqInstances.scala
@@ -25,25 +25,25 @@ trait EqInstances {
       val ctx = retrySample[Map[String, String]]
       val throwable = retrySample[Throwable]
       eqF.eqv(x.trace(msg), y.trace(msg)) &&
-      eqF.eqv(x.trace(msg, throwable), y.trace(msg, throwable)) &&
+      eqF.eqv(x.trace[String, Throwable](msg, throwable), y.trace[String, Throwable](msg, throwable)) &&
       eqF.eqv(x.trace(msg, ctx), y.trace(msg, ctx)) &&
-      eqF.eqv(x.trace(msg, ctx, throwable), y.trace(msg, ctx, throwable)) &&
+      eqF.eqv(x.trace[String, Throwable](msg, ctx, throwable), y.trace[String, Throwable](msg, ctx, throwable)) &&
       eqF.eqv(x.debug(msg), y.debug(msg)) &&
-      eqF.eqv(x.debug(msg, throwable), y.debug(msg, throwable)) &&
+      eqF.eqv(x.debug[String, Throwable](msg, throwable), y.debug[String, Throwable](msg, throwable)) &&
       eqF.eqv(x.debug(msg, ctx), y.debug(msg, ctx)) &&
-      eqF.eqv(x.debug(msg, ctx, throwable), y.debug(msg, ctx, throwable)) &&
+      eqF.eqv(x.debug[String, Throwable](msg, ctx, throwable), y.debug[String, Throwable](msg, ctx, throwable)) &&
       eqF.eqv(x.info(msg), y.info(msg)) &&
-      eqF.eqv(x.info(msg, throwable), y.info(msg, throwable)) &&
+      eqF.eqv(x.info[String, Throwable](msg, throwable), y.info[String, Throwable](msg, throwable)) &&
       eqF.eqv(x.info(msg, ctx), y.info(msg, ctx)) &&
-      eqF.eqv(x.info(msg, ctx, throwable), y.info(msg, ctx, throwable)) &&
+      eqF.eqv(x.info[String, Throwable](msg, ctx, throwable), y.info[String, Throwable](msg, ctx, throwable)) &&
       eqF.eqv(x.warn(msg), y.warn(msg)) &&
-      eqF.eqv(x.warn(msg, throwable), y.warn(msg, throwable)) &&
+      eqF.eqv(x.warn[String, Throwable](msg, throwable), y.warn[String, Throwable](msg, throwable)) &&
       eqF.eqv(x.warn(msg, ctx), y.warn(msg, ctx)) &&
-      eqF.eqv(x.warn(msg, ctx, throwable), y.warn(msg, ctx, throwable)) &&
+      eqF.eqv(x.warn[String, Throwable](msg, ctx, throwable), y.warn[String, Throwable](msg, ctx, throwable)) &&
       eqF.eqv(x.error(msg), y.error(msg)) &&
-      eqF.eqv(x.error(msg, throwable), y.error(msg, throwable)) &&
+      eqF.eqv(x.error[String, Throwable](msg, throwable), y.error[String, Throwable](msg, throwable)) &&
       eqF.eqv(x.error(msg, ctx), y.error(msg, ctx)) &&
-      eqF.eqv(x.error(msg, ctx, throwable), y.error(msg, ctx, throwable))
+      eqF.eqv(x.error[String, Throwable](msg, ctx, throwable), y.error[String, Throwable](msg, ctx, throwable))
     }
 
   implicit def eqIO[A](implicit eqA: Eq[A]): Eq[IO[A]] = Eq.instance { (ioA, ioB) =>

--- a/core/src/test/scala/io/odin/loggers/DefaultLoggerSpec.scala
+++ b/core/src/test/scala/io/odin/loggers/DefaultLoggerSpec.scala
@@ -17,29 +17,29 @@ class DefaultLoggerSpec extends OdinSpec {
       implicit val clk: Timer[Id] = clock(timestamp)
       val log = logger.withMinimalLevel(Level.Trace)
       check(log.trace(msg))(Level.Trace, msg, timestamp)
-      check(log.trace(msg, throwable))(Level.Trace, msg, timestamp, throwable = Some(throwable))
+      check(log.trace[String, Throwable](msg, throwable))(Level.Trace, msg, timestamp, throwable = Some(throwable))
       check(log.trace(msg, ctx))(Level.Trace, msg, timestamp, ctx)
-      check(log.trace(msg, ctx, throwable))(Level.Trace, msg, timestamp, ctx, Some(throwable))
+      check(log.trace[String, Throwable](msg, ctx, throwable))(Level.Trace, msg, timestamp, ctx, Some(throwable))
 
       check(log.debug(msg))(Level.Debug, msg, timestamp)
-      check(log.debug(msg, throwable))(Level.Debug, msg, timestamp, throwable = Some(throwable))
+      check(log.debug[String, Throwable](msg, throwable))(Level.Debug, msg, timestamp, throwable = Some(throwable))
       check(log.debug(msg, ctx))(Level.Debug, msg, timestamp, ctx)
-      check(log.debug(msg, ctx, throwable))(Level.Debug, msg, timestamp, ctx, Some(throwable))
+      check(log.debug[String, Throwable](msg, ctx, throwable))(Level.Debug, msg, timestamp, ctx, Some(throwable))
 
       check(log.info(msg))(Level.Info, msg, timestamp)
-      check(log.info(msg, throwable))(Level.Info, msg, timestamp, throwable = Some(throwable))
+      check(log.info[String, Throwable](msg, throwable))(Level.Info, msg, timestamp, throwable = Some(throwable))
       check(log.info(msg, ctx))(Level.Info, msg, timestamp, ctx)
-      check(log.info(msg, ctx, throwable))(Level.Info, msg, timestamp, ctx, Some(throwable))
+      check(log.info[String, Throwable](msg, ctx, throwable))(Level.Info, msg, timestamp, ctx, Some(throwable))
 
       check(log.warn(msg))(Level.Warn, msg, timestamp)
-      check(log.warn(msg, throwable))(Level.Warn, msg, timestamp, throwable = Some(throwable))
+      check(log.warn[String, Throwable](msg, throwable))(Level.Warn, msg, timestamp, throwable = Some(throwable))
       check(log.warn(msg, ctx))(Level.Warn, msg, timestamp, ctx)
-      check(log.warn(msg, ctx, throwable))(Level.Warn, msg, timestamp, ctx, Some(throwable))
+      check(log.warn[String, Throwable](msg, ctx, throwable))(Level.Warn, msg, timestamp, ctx, Some(throwable))
 
       check(log.error(msg))(Level.Error, msg, timestamp)
-      check(log.error(msg, throwable))(Level.Error, msg, timestamp, throwable = Some(throwable))
+      check(log.error[String, Throwable](msg, throwable))(Level.Error, msg, timestamp, throwable = Some(throwable))
       check(log.error(msg, ctx))(Level.Error, msg, timestamp, ctx)
-      check(log.error(msg, ctx, throwable))(Level.Error, msg, timestamp, ctx, Some(throwable))
+      check(log.error[String, Throwable](msg, ctx, throwable))(Level.Error, msg, timestamp, ctx, Some(throwable))
     }
   }
 

--- a/core/src/test/scala/io/odin/loggers/LoggerLaws.scala
+++ b/core/src/test/scala/io/odin/loggers/LoggerLaws.scala
@@ -17,27 +17,32 @@ trait LoggerLaws[F[_]] {
   ): IsEq[List[LoggerMessage]] = {
     def trace(l: Logger[F]): F[Unit] =
       l.trace(msg.message.value) >> l.trace(msg.message.value, msg.context) >> F.whenA(msg.exception.isDefined) {
-        l.trace(msg.message.value, msg.exception.get) >> l.trace(msg.message.value, msg.context, msg.exception.get)
+        l.trace[String, Throwable](msg.message.value, msg.exception.get) >>
+          l.trace[String, Throwable](msg.message.value, msg.context, msg.exception.get)
       }
 
     def debug(l: Logger[F]): F[Unit] =
       l.debug(msg.message.value) >> l.debug(msg.message.value, msg.context) >> F.whenA(msg.exception.isDefined) {
-        l.debug(msg.message.value, msg.exception.get) >> l.debug(msg.message.value, msg.context, msg.exception.get)
+        l.debug[String, Throwable](msg.message.value, msg.exception.get) >>
+          l.debug[String, Throwable](msg.message.value, msg.context, msg.exception.get)
       }
 
     def info(l: Logger[F]): F[Unit] =
       l.info(msg.message.value) >> l.info(msg.message.value, msg.context) >> F.whenA(msg.exception.isDefined) {
-        l.info(msg.message.value, msg.exception.get) >> l.info(msg.message.value, msg.context, msg.exception.get)
+        l.info[String, Throwable](msg.message.value, msg.exception.get) >>
+          l.info[String, Throwable](msg.message.value, msg.context, msg.exception.get)
       }
 
     def warn(l: Logger[F]): F[Unit] =
       l.warn(msg.message.value) >> l.warn(msg.message.value, msg.context) >> F.whenA(msg.exception.isDefined) {
-        l.warn(msg.message.value, msg.exception.get) >> l.warn(msg.message.value, msg.context, msg.exception.get)
+        l.warn[String, Throwable](msg.message.value, msg.exception.get) >>
+          l.warn[String, Throwable](msg.message.value, msg.context, msg.exception.get)
       }
 
     def error(l: Logger[F]): F[Unit] =
       l.error(msg.message.value) >> l.error(msg.message.value, msg.context) >> F.whenA(msg.exception.isDefined) {
-        l.error(msg.message.value, msg.exception.get) >> l.error(msg.message.value, msg.context, msg.exception.get)
+        l.error[String, Throwable](msg.message.value, msg.exception.get) >>
+          l.error[String, Throwable](msg.message.value, msg.context, msg.exception.get)
       }
 
     def all(l: Logger[F]): F[Unit] =

--- a/core/src/test/scala/io/odin/loggers/LoggerNatTransformSpec.scala
+++ b/core/src/test/scala/io/odin/loggers/LoggerNatTransformSpec.scala
@@ -17,29 +17,29 @@ class LoggerNatTransformSpec extends OdinSpec {
       val logF = logger.withMinimalLevel(Level.Trace)
       val logFF = logF.mapK(nat).withMinimalLevel(Level.Trace)
       check(logF.trace(msg), logFF.trace(msg))
-      check(logF.trace(msg, throwable), logFF.trace(msg, throwable))
+      check(logF.trace[String, Throwable](msg, throwable), logFF.trace[String, Throwable](msg, throwable))
       check(logF.trace(msg, ctx), logFF.trace(msg, ctx))
-      check(logF.trace(msg, ctx, throwable), logFF.trace(msg, ctx, throwable))
+      check(logF.trace[String, Throwable](msg, ctx, throwable), logFF.trace[String, Throwable](msg, ctx, throwable))
 
       check(logF.debug(msg), logFF.debug(msg))
-      check(logF.debug(msg, throwable), logFF.debug(msg, throwable))
+      check(logF.debug[String, Throwable](msg, throwable), logFF.debug[String, Throwable](msg, throwable))
       check(logF.debug(msg, ctx), logFF.debug(msg, ctx))
-      check(logF.debug(msg, ctx, throwable), logFF.debug(msg, ctx, throwable))
+      check(logF.debug[String, Throwable](msg, ctx, throwable), logFF.debug[String, Throwable](msg, ctx, throwable))
 
       check(logF.info(msg), logFF.info(msg))
-      check(logF.info(msg, throwable), logFF.info(msg, throwable))
+      check(logF.info[String, Throwable](msg, throwable), logFF.info[String, Throwable](msg, throwable))
       check(logF.info(msg, ctx), logFF.info(msg, ctx))
-      check(logF.info(msg, ctx, throwable), logFF.info(msg, ctx, throwable))
+      check(logF.info[String, Throwable](msg, ctx, throwable), logFF.info[String, Throwable](msg, ctx, throwable))
 
       check(logF.warn(msg), logFF.warn(msg))
-      check(logF.warn(msg, throwable), logFF.warn(msg, throwable))
+      check(logF.warn[String, Throwable](msg, throwable), logFF.warn[String, Throwable](msg, throwable))
       check(logF.warn(msg, ctx), logFF.warn(msg, ctx))
-      check(logF.warn(msg, ctx, throwable), logFF.warn(msg, ctx, throwable))
+      check(logF.warn[String, Throwable](msg, ctx, throwable), logFF.warn[String, Throwable](msg, ctx, throwable))
 
       check(logF.error(msg), logFF.error(msg))
-      check(logF.error(msg, throwable), logFF.error(msg, throwable))
+      check(logF.error[String, Throwable](msg, throwable), logFF.error[String, Throwable](msg, throwable))
       check(logF.error(msg, ctx), logFF.error(msg, ctx))
-      check(logF.error(msg, ctx, throwable), logFF.error(msg, ctx, throwable))
+      check(logF.error[String, Throwable](msg, ctx, throwable), logFF.error[String, Throwable](msg, ctx, throwable))
     }
   }
 


### PR DESCRIPTION
This PR closes #76.

The disadvantage of the deprecation cycle is that types must be provided explicitly because compiler chooses `info(msg: M, t: Throwable)` instead of `info(msg: M, e: E)`. Example:

```scala
val exception = new RuntimeException("error")
logger.info("old method", exception) // raise deprecation warning
logger.info[String, Throwable]("new method", exception) // everything works fine
```

In theory, old methods can be removed and the users will not even notice it. Plus bin compat is broken anyway.
