### PR TITLE
Add formatter factory method

### DIFF
--- a/benchmarks/src/main/scala/io/odin/Benchmarks.scala
+++ b/benchmarks/src/main/scala/io/odin/Benchmarks.scala
@@ -9,6 +9,7 @@ import cats.effect.{ContextShift, IO, Timer}
 import io.odin.loggers.DefaultLogger
 import io.odin.syntax._
 import io.odin.formatter.Formatter
+import io.odin.formatter.options.ThrowableFormat
 import io.odin.json.{Formatter => JsonFormatter}
 import io.odin.meta.Position
 import org.openjdk.jmh.annotations._
@@ -205,8 +206,21 @@ class FormatterBenchmarks extends OdinBenchmarks {
   private val noCtx: LoggerMessage = loggerMessage.copy(context = Map.empty)
   private val noThrowable: LoggerMessage = noCtx.copy(exception = None)
 
+  private val formatterDepth = Formatter.create(
+    ThrowableFormat(ThrowableFormat.Depth.Fixed(2), ThrowableFormat.Indent.NoIndent),
+    colorful = false
+  )
+
+  private val formatterDepthIndent = Formatter.create(
+    ThrowableFormat(ThrowableFormat.Depth.Fixed(2), ThrowableFormat.Indent.Fixed(4)),
+    colorful = false
+  )
+
   @Benchmark
   def defaultFormatter(): Unit = Formatter.default.format(loggerMessage)
+
+  @Benchmark
+  def defaultColorful(): Unit = Formatter.colorful.format(loggerMessage)
 
   @Benchmark
   def defaultFormatterNoCtx(): Unit = Formatter.default.format(noCtx)
@@ -216,6 +230,13 @@ class FormatterBenchmarks extends OdinBenchmarks {
 
   @Benchmark
   def jsonFormatter(): Unit = JsonFormatter.json.format(loggerMessage)
+
+  @Benchmark
+  def depthFormatter(): Unit = formatterDepth.format(loggerMessage)
+
+  @Benchmark
+  def depthIndentFormatter(): Unit = formatterDepthIndent.format(loggerMessage)
+
 }
 
 @State(Scope.Benchmark)

--- a/core/src/main/scala/io/odin/formatter/Formatter.scala
+++ b/core/src/main/scala/io/odin/formatter/Formatter.scala
@@ -2,10 +2,11 @@ package io.odin.formatter
 
 import cats.syntax.show._
 import io.odin.LoggerMessage
+import io.odin.formatter.options.ThrowableFormat
 import perfolation._
-import scala.io.AnsiColor._
 
 import scala.annotation.tailrec
+import scala.io.AnsiColor._
 
 trait Formatter {
   def format(msg: LoggerMessage): String
@@ -15,29 +16,41 @@ object Formatter {
 
   val BRIGHT_BLACK = "\u001b[30;1m"
 
-  val default: Formatter = (msg: LoggerMessage) => {
-    val ctx = formatCtx(msg.context)
-    val lineNumber = if (msg.position.line >= 0) p":${msg.position.line}" else ""
-    val throwable = msg.exception match {
-      case Some(t) =>
-        p"${System.lineSeparator()}${formatThrowable(t).toString}"
-      case None =>
-        ""
-    }
-    p"${msg.timestamp.t.F}T${msg.timestamp.t.T} [${msg.threadName}] ${msg.level.show} ${msg.position.enclosureName}$lineNumber - ${msg.message.value}$ctx${System
-      .lineSeparator()}${throwable.toString}"
-  }
+  val default: Formatter = Formatter.create(ThrowableFormat.Default, colorful = false)
 
-  val colorful: Formatter = (msg: LoggerMessage) => {
-    val ctx = formatCtx(msg.context)
-    val lineNumber = if (msg.position.line >= 0) p":${msg.position.line}" else ""
-    val throwable = msg.exception match {
-      case Some(t) =>
-        p"${System.lineSeparator()}${formatThrowable(t).toString}"
-      case None =>
-        ""
+  val colorful: Formatter = Formatter.create(ThrowableFormat.Default, colorful = true)
+
+  /**
+    * Creates new formatter with provided options
+    *
+    * @param throwableFormat @see [[formatThrowable]]
+    * @param colorful use different color for thread name, level, position and throwable
+    */
+  def create(throwableFormat: ThrowableFormat, colorful: Boolean): Formatter = {
+
+    @inline def withColor(color: String, message: String): String =
+      if (colorful) p"$color$message$RESET" else message
+
+    (msg: LoggerMessage) => {
+      val ctx = withColor(MAGENTA, formatCtx(msg.context))
+      val timestamp = p"${msg.timestamp.t.F}T${msg.timestamp.t.T},${msg.timestamp.t.milliOfSecond}"
+      val threadName = withColor(GREEN, msg.threadName)
+      val level = withColor(BRIGHT_BLACK, msg.level.show)
+
+      val position = {
+        val lineNumber = if (msg.position.line >= 0) p":${msg.position.line}" else ""
+        withColor(BLUE, p"${msg.position.enclosureName}$lineNumber")
+      }
+
+      val throwable = msg.exception match {
+        case Some(t) =>
+          withColor(RED, p"${System.lineSeparator()}${formatThrowable(t, throwableFormat)}")
+        case None =>
+          ""
+      }
+
+      p"$timestamp [$threadName] $level $position - ${msg.message.value}$ctx$throwable"
     }
-    p"${msg.timestamp.t.F}T${msg.timestamp.t.T} $GREEN[${msg.threadName}]$RESET $BRIGHT_BLACK${msg.level.show}$RESET $BLUE${msg.position.enclosureName}$lineNumber$RESET - ${msg.message.value}$MAGENTA$ctx$RESET$RED$throwable$RESET"
   }
 
   def formatCtx(context: Map[String, String]): String =
@@ -56,28 +69,50 @@ object Formatter {
 
   /**
     * Default Throwable printer is twice as slow. This method was borrowed from scribe library.
+    *
+    * The result differs depending on the format:
+    * [[ThrowableFormat.Depth.Full]] - prints all elements of a stack trace
+    * [[ThrowableFormat.Depth.Fixed]] - prints N elements of a stack trace
+    * [[ThrowableFormat.Indent.NoIndent]] - prints a stack trace without indentation
+    * [[ThrowableFormat.Indent.Fixed]] - prints a stack trace prepending every line with N spaces
     */
-  def formatThrowable(t: Throwable, builder: StringBuilder = new StringBuilder): StringBuilder = {
-    builder.append("Caused by: ")
-    builder.append(t.getClass.getName)
-    if (Option(t.getLocalizedMessage).isDefined) {
-      builder.append(": ")
-      builder.append(t.getLocalizedMessage)
+  def formatThrowable(t: Throwable, format: ThrowableFormat): String = {
+    val indent = format.indent match {
+      case ThrowableFormat.Indent.NoIndent    => ""
+      case ThrowableFormat.Indent.Fixed(size) => "".padTo(size, ' ')
     }
-    builder.append(System.lineSeparator())
-    writeStackTrace(builder, t.getStackTrace)
-    if (Option(t.getCause).isEmpty) {
-      builder
-    } else {
-      formatThrowable(t.getCause, builder)
+
+    val depth: Option[Int] = format.depth match {
+      case ThrowableFormat.Depth.Full        => None
+      case ThrowableFormat.Depth.Fixed(size) => Some(size)
     }
+
+    @tailrec
+    def loop(t: Throwable, builder: StringBuilder): StringBuilder = {
+      builder.append("Caused by: ")
+      builder.append(t.getClass.getName)
+      if (Option(t.getLocalizedMessage).isDefined) {
+        builder.append(": ")
+        builder.append(t.getLocalizedMessage)
+      }
+      builder.append(System.lineSeparator())
+      writeStackTrace(builder, depth.fold(t.getStackTrace)(t.getStackTrace.take), indent)
+      if (Option(t.getCause).isEmpty) {
+        builder
+      } else {
+        loop(t.getCause, builder)
+      }
+    }
+
+    loop(t, new StringBuilder).toString()
   }
 
   @tailrec
-  private def writeStackTrace(b: StringBuilder, elements: Array[StackTraceElement]): Unit = {
+  private def writeStackTrace(b: StringBuilder, elements: Array[StackTraceElement], indent: String): Unit = {
     elements.headOption match {
       case None => // No more elements
       case Some(head) =>
+        b.append(indent)
         b.append(head.getClassName)
         b.append('.')
         b.append(head.getMethodName)
@@ -89,7 +124,7 @@ object Formatter {
         }
         b.append(')')
         b.append(System.lineSeparator())
-        writeStackTrace(b, elements.tail)
+        writeStackTrace(b, elements.tail, indent)
     }
   }
 }

--- a/core/src/main/scala/io/odin/formatter/options/ThrowableFormat.scala
+++ b/core/src/main/scala/io/odin/formatter/options/ThrowableFormat.scala
@@ -1,0 +1,21 @@
+package io.odin.formatter.options
+
+final case class ThrowableFormat(depth: ThrowableFormat.Depth, indent: ThrowableFormat.Indent)
+
+object ThrowableFormat {
+
+  val Default: ThrowableFormat = ThrowableFormat(Depth.Full, Indent.NoIndent)
+
+  sealed trait Depth
+  object Depth {
+    final case object Full extends Depth
+    final case class Fixed(size: Int) extends Depth
+  }
+
+  sealed trait Indent
+  object Indent {
+    final case object NoIndent extends Indent
+    final case class Fixed(size: Int) extends Indent
+  }
+
+}

--- a/core/src/test/scala/io/odin/formatter/FormatterSpec.scala
+++ b/core/src/test/scala/io/odin/formatter/FormatterSpec.scala
@@ -1,0 +1,88 @@
+package io.odin.formatter
+
+import io.odin.OdinSpec
+import io.odin.formatter.options.ThrowableFormat
+import io.odin.formatter.options.ThrowableFormat.{Depth, Indent}
+import io.odin.formatter.FormatterSpec.TestException
+import org.scalacheck.Gen
+
+import scala.util.control.NoStackTrace
+
+class FormatterSpec extends OdinSpec {
+
+  behavior of "Formatter.formatThrowable with ThrowableFormat"
+
+  it should "support Indent" in forAll(indentGen) { indent =>
+    val indentStr = indent match {
+      case Indent.NoIndent    => ""
+      case Indent.Fixed(size) => "".padTo(size, ' ')
+    }
+
+    val error1 = TestException("Exception 1")
+    val error2 = new RuntimeException("Exception 2", error1)
+
+    val format = ThrowableFormat(Depth.Full, indent)
+    val result = Formatter.formatThrowable(error2, format)
+    val lines = result.split(System.lineSeparator()).toList
+
+    val (cause, trace) = lines.partition(_.startsWith("Caused by"))
+
+    val expectedCausedBy = List(
+      "Caused by: java.lang.RuntimeException: Exception 2",
+      s"Caused by: io.odin.formatter.FormatterSpec$$TestException: Exception 1"
+    )
+
+    cause shouldBe expectedCausedBy
+    trace.forall(_.startsWith(indentStr)) shouldBe true
+  }
+
+  it should "support Depth" in forAll(depthGen) { depth =>
+    val indent = Indent.Fixed(2)
+
+    val depthSize = depth match {
+      case Depth.Full        => None
+      case Depth.Fixed(size) => Some(size)
+    }
+
+    val error1 = TestException("Exception 1")
+    val error2 = new RuntimeException("Exception 2", error1)
+
+    val format = ThrowableFormat(depth, indent)
+    val result = Formatter.formatThrowable(error2, format)
+    val lines = result.split(System.lineSeparator()).toList
+
+    val (cause, trace) = lines.partition(_.startsWith("Caused by"))
+
+    val expectedCausedBy = List(
+      "Caused by: java.lang.RuntimeException: Exception 2",
+      s"Caused by: io.odin.formatter.FormatterSpec$$TestException: Exception 1"
+    )
+
+    val expectedLength = {
+      val stackTraceLength = error2.getStackTrace.length
+      depthSize.fold(stackTraceLength)(size => stackTraceLength.min(size))
+    }
+
+    cause shouldBe expectedCausedBy
+    trace.length shouldBe expectedLength
+  }
+
+  private lazy val indentGen: Gen[Indent] =
+    Gen.oneOf(
+      Gen.const(Indent.NoIndent),
+      Gen.posNum[Int].filter(_ > 0).map(size => Indent.Fixed(size))
+    )
+
+  private lazy val depthGen: Gen[Depth] =
+    Gen.oneOf(
+      Gen.const(Depth.Full),
+      Gen.posNum[Int].map(size => Depth.Fixed(size))
+    )
+
+}
+
+object FormatterSpec {
+
+  final case class TestException(message: String) extends Throwable(message) with NoStackTrace
+
+}


### PR DESCRIPTION
This PR closes #79.  

# Benchmarks

The master branch:

| Benchmark                                          | Mode | Cnt | Score     | Error     | Units |
|----------------------------------------------------|------|-----|-----------|-----------|-------|
| FormatterBenchmarks.defaultFormatter               | avgt | 25  | 3216.710  | ±111.699 | ns/op |
| FormatterBenchmarks.defaultFormatterNoCtx          | avgt | 25  | 3231.479  | ±242.436 | ns/op |
| FormatterBenchmarks.defaultFormatterNoCtxThrowable | avgt | 25  | 415.155   | ±10.236  | ns/op |
| FormatterBenchmarks.jsonFormatter                  | avgt | 25  | 13510.848 | ±506.265 | ns/op |

The formatter factory branch:

| Benchmark                                          | Mode | Cnt | Score      | Error       | Units |
|----------------------------------------------------|------|-----|------------|-------------|-------|
| FormatterBenchmarks.defaultFormatter               | avgt | 25  | 3365.329   | ±64.852     | ns/op |
| FormatterBenchmarks.defaultFormatterNoCtx          | avgt | 25  | 3319.644   | ±70.451     | ns/op |
| FormatterBenchmarks.defaultFormatterNoCtxThrowable | avgt | 25  | 515.835    | ±10.149     | ns/op |
| FormatterBenchmarks.jsonFormatter                  | avgt | 25  | 13250.911  | ±258.674    | ns/op |
| FormatterBenchmarks.defaultColorful                | avgt | 25  | 3848.390   | ±142.849    | ns/op |
| FormatterBenchmarks.depthFormatter                 | avgt | 25  | 975.509    | ±13.296     | ns/op |
| FormatterBenchmarks.depthIndentFormatter           | avgt | 25  | 1053.433   | ±18.674     | ns/op |
| FormatterBenchmarks.timestampPatternFormatter      | avgt | 25  | 156076.212 | ±183102.680 | ns/op |

The execution time is almost the same.

As you can see, the performance of `timestampPatternFormatter` is unacceptable. I've started with the naive idea of using `java.time.format.DateTimeFormatter`, but it's extremely inefficient. Plus I don't think that it will be a common use case. Thus I removed it from the PR.
