### PR TITLE
Add position formatter

### DIFF
--- a/benchmarks/src/main/scala/io/odin/Benchmarks.scala
+++ b/benchmarks/src/main/scala/io/odin/Benchmarks.scala
@@ -9,7 +9,7 @@ import cats.effect.{ContextShift, IO, Timer}
 import io.odin.loggers.DefaultLogger
 import io.odin.syntax._
 import io.odin.formatter.Formatter
-import io.odin.formatter.options.ThrowableFormat
+import io.odin.formatter.options.{PositionFormat, ThrowableFormat}
 import io.odin.json.{Formatter => JsonFormatter}
 import io.odin.meta.Position
 import org.openjdk.jmh.annotations._
@@ -208,11 +208,19 @@ class FormatterBenchmarks extends OdinBenchmarks {
 
   private val formatterDepth = Formatter.create(
     ThrowableFormat(ThrowableFormat.Depth.Fixed(2), ThrowableFormat.Indent.NoIndent),
+    PositionFormat.Full,
     colorful = false
   )
 
   private val formatterDepthIndent = Formatter.create(
     ThrowableFormat(ThrowableFormat.Depth.Fixed(2), ThrowableFormat.Indent.Fixed(4)),
+    PositionFormat.Full,
+    colorful = false
+  )
+
+  private val abbreviated = Formatter.create(
+    ThrowableFormat.Default,
+    PositionFormat.AbbreviatePackage,
     colorful = false
   )
 
@@ -236,6 +244,9 @@ class FormatterBenchmarks extends OdinBenchmarks {
 
   @Benchmark
   def depthIndentFormatter(): Unit = formatterDepthIndent.format(loggerMessage)
+
+  @Benchmark
+  def abbreviatedPositionFormatter(): Unit = abbreviated.format(loggerMessage)
 
 }
 

--- a/core/src/main/scala/io/odin/formatter/Formatter.scala
+++ b/core/src/main/scala/io/odin/formatter/Formatter.scala
@@ -21,6 +21,9 @@ object Formatter {
 
   val colorful: Formatter = Formatter.create(ThrowableFormat.Default, PositionFormat.Full, colorful = true)
 
+  def create(throwableFormat: ThrowableFormat, colorful: Boolean): Formatter =
+    create(throwableFormat, PositionFormat.Full, colorful)
+
   /**
     * Creates new formatter with provided options
     *
@@ -76,10 +79,10 @@ object Formatter {
   /**
     * The result differs depending on the format:
     *
-    * [[PositionFormat.Full]] - prints full position
+    * `PositionFormat.Full` - prints full position
     * 'io.odin.formatter.Formatter formatPosition:75' formatted as 'io.odin.formatter.Formatter formatPosition:75'
     *
-    * [[PositionFormat.AbbreviatePackage]] - prints abbreviated package and full enclosing
+    * `PositionFormat.AbbreviatePackage` - prints abbreviated package and full enclosing
     * 'io.odin.formatter.Formatter formatPosition:75' formatted as 'i.o.f.Formatter formatPosition:75'
     */
   def formatPosition(position: Position, format: PositionFormat): String = {
@@ -98,10 +101,10 @@ object Formatter {
     * Default Throwable printer is twice as slow. This method was borrowed from scribe library.
     *
     * The result differs depending on the format:
-    * [[ThrowableFormat.Depth.Full]] - prints all elements of a stack trace
-    * [[ThrowableFormat.Depth.Fixed]] - prints N elements of a stack trace
-    * [[ThrowableFormat.Indent.NoIndent]] - prints a stack trace without indentation
-    * [[ThrowableFormat.Indent.Fixed]] - prints a stack trace prepending every line with N spaces
+    * `ThrowableFormat.Depth.Full` - prints all elements of a stack trace
+    * `ThrowableFormat.Depth.Fixed` - prints N elements of a stack trace
+    * `ThrowableFormat.Indent.NoIndent` - prints a stack trace without indentation
+    * `ThrowableFormat.Indent.Fixed` - prints a stack trace prepending every line with N spaces
     */
   def formatThrowable(t: Throwable, format: ThrowableFormat): String = {
     val indent = format.indent match {
@@ -157,15 +160,21 @@ object Formatter {
 
   private def abbreviate(enclosure: String): String = {
     @tailrec
-    def loop(input: List[String], builder: StringBuilder): StringBuilder = {
-      input match {
-        case Nil          => builder
-        case head :: Nil  => builder.append(head)
-        case head :: tail => loop(tail, builder.append(head.headOption.getOrElse('?')).append('.'))
+    def loop(input: Array[String], builder: StringBuilder): StringBuilder = {
+      input.length match {
+        case 0 => builder
+        case 1 => builder.append(input.head)
+        case _ =>
+          val head = input.head
+          val b = if (head.isEmpty) builder.append(questionMark) else builder.append(head.head)
+          loop(input.tail, b.append(dot))
       }
     }
 
-    loop(enclosure.split('.').toList, new StringBuilder).toString()
+    loop(enclosure.split('.'), new StringBuilder).toString()
   }
+
+  private val questionMark = "?"
+  private val dot = "."
 
 }

--- a/core/src/main/scala/io/odin/formatter/Formatter.scala
+++ b/core/src/main/scala/io/odin/formatter/Formatter.scala
@@ -2,7 +2,8 @@ package io.odin.formatter
 
 import cats.syntax.show._
 import io.odin.LoggerMessage
-import io.odin.formatter.options.ThrowableFormat
+import io.odin.formatter.options.{PositionFormat, ThrowableFormat}
+import io.odin.meta.Position
 import perfolation._
 
 import scala.annotation.tailrec
@@ -16,31 +17,28 @@ object Formatter {
 
   val BRIGHT_BLACK = "\u001b[30;1m"
 
-  val default: Formatter = Formatter.create(ThrowableFormat.Default, colorful = false)
+  val default: Formatter = Formatter.create(ThrowableFormat.Default, PositionFormat.Full, colorful = false)
 
-  val colorful: Formatter = Formatter.create(ThrowableFormat.Default, colorful = true)
+  val colorful: Formatter = Formatter.create(ThrowableFormat.Default, PositionFormat.Full, colorful = true)
 
   /**
     * Creates new formatter with provided options
     *
     * @param throwableFormat @see [[formatThrowable]]
+    * @param positionFormat @see [[formatPosition]]
     * @param colorful use different color for thread name, level, position and throwable
     */
-  def create(throwableFormat: ThrowableFormat, colorful: Boolean): Formatter = {
+  def create(throwableFormat: ThrowableFormat, positionFormat: PositionFormat, colorful: Boolean): Formatter = {
 
     @inline def withColor(color: String, message: String): String =
       if (colorful) p"$color$message$RESET" else message
 
     (msg: LoggerMessage) => {
       val ctx = withColor(MAGENTA, formatCtx(msg.context))
-      val timestamp = p"${msg.timestamp.t.F}T${msg.timestamp.t.T},${msg.timestamp.t.milliOfSecond}"
+      val timestamp = formatTimestamp(msg.timestamp)
       val threadName = withColor(GREEN, msg.threadName)
       val level = withColor(BRIGHT_BLACK, msg.level.show)
-
-      val position = {
-        val lineNumber = if (msg.position.line >= 0) p":${msg.position.line}" else ""
-        withColor(BLUE, p"${msg.position.enclosureName}$lineNumber")
-      }
+      val position = withColor(BLUE, formatPosition(msg.position, positionFormat))
 
       val throwable = msg.exception match {
         case Some(t) =>
@@ -68,13 +66,42 @@ object Formatter {
     }
 
   /**
+    * Formats timestamp using the following format: yyyy-MM-ddTHH:mm:ss,SSS
+    */
+  def formatTimestamp(timestamp: Long): String = {
+    val date = timestamp.t
+    p"${date.F}T${date.T},${date.milliOfSecond}"
+  }
+
+  /**
+    * The result differs depending on the format:
+    *
+    * [[PositionFormat.Full]] - prints full position
+    * 'io.odin.formatter.Formatter formatPosition:75' formatted as 'io.odin.formatter.Formatter formatPosition:75'
+    *
+    * [[PositionFormat.AbbreviatePackage]] - prints abbreviated package and full enclosing
+    * 'io.odin.formatter.Formatter formatPosition:75' formatted as 'i.o.f.Formatter formatPosition:75'
+    */
+  def formatPosition(position: Position, format: PositionFormat): String = {
+    val lineNumber = if (position.line >= 0) p":${position.line}" else ""
+
+    val enclosure = format match {
+      case PositionFormat.Full              => position.enclosureName
+      case PositionFormat.AbbreviatePackage => abbreviate(position.enclosureName)
+
+    }
+
+    p"$enclosure$lineNumber"
+  }
+
+  /**
     * Default Throwable printer is twice as slow. This method was borrowed from scribe library.
     *
     * The result differs depending on the format:
-    * `ThrowableFormat.Depth.Full` - prints all elements of a stack trace
-    * `ThrowableFormat.Depth.Fixed` - prints N elements of a stack trace
-    * `ThrowableFormat.Indent.NoIndent` - prints a stack trace without indentation
-    * `ThrowableFormat.Indent.Fixed` - prints a stack trace prepending every line with N spaces
+    * [[ThrowableFormat.Depth.Full]] - prints all elements of a stack trace
+    * [[ThrowableFormat.Depth.Fixed]] - prints N elements of a stack trace
+    * [[ThrowableFormat.Indent.NoIndent]] - prints a stack trace without indentation
+    * [[ThrowableFormat.Indent.Fixed]] - prints a stack trace prepending every line with N spaces
     */
   def formatThrowable(t: Throwable, format: ThrowableFormat): String = {
     val indent = format.indent match {
@@ -127,4 +154,18 @@ object Formatter {
         writeStackTrace(b, elements.tail, indent)
     }
   }
+
+  private def abbreviate(enclosure: String): String = {
+    @tailrec
+    def loop(input: List[String], builder: StringBuilder): StringBuilder = {
+      input match {
+        case Nil          => builder
+        case head :: Nil  => builder.append(head)
+        case head :: tail => loop(tail, builder.append(head.headOption.getOrElse('?')).append('.'))
+      }
+    }
+
+    loop(enclosure.split('.').toList, new StringBuilder).toString()
+  }
+
 }

--- a/core/src/main/scala/io/odin/formatter/options/PositionFormat.scala
+++ b/core/src/main/scala/io/odin/formatter/options/PositionFormat.scala
@@ -1,0 +1,8 @@
+package io.odin.formatter.options
+
+sealed trait PositionFormat
+
+object PositionFormat {
+  final case object Full extends PositionFormat
+  final case object AbbreviatePackage extends PositionFormat
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -253,12 +253,14 @@ Beside copy-pasting the existing formatter to adjust it for one's needs, it's po
 
 ```scala
 object Formatter {
-  def create(throwableFormat: ThrowableFormat, colorful: Boolean): Formatter
+  def create(throwableFormat: ThrowableFormat, positionFormat: PositionFormat, colorful: Boolean): Formatter
 }
 ```
 
 - [`ThrowableFormat`](https://github.com/valskalla/odin/blob/master/core/src/main/scala/io/odin/formatter/options/ThrowableFormat.scala)
 allows to tweak the rendering of exceptions, specifically indentation and stack depth.
+- [`PositionFormat`](https://github.com/valskalla/odin/blob/master/core/src/main/scala/io/odin/formatter/options/PositionFormat.scala)
+allows to tweak the rendering of position.
 - `colorful` flag enables logs highlighting.
 
 ## Minimal level

--- a/json/src/main/scala/io/odin/json/Formatter.scala
+++ b/json/src/main/scala/io/odin/json/Formatter.scala
@@ -12,6 +12,9 @@ object Formatter {
 
   val json: OFormatter = create(ThrowableFormat.Default, PositionFormat.Full)
 
+  def create(throwableFormat: ThrowableFormat): OFormatter =
+    create(throwableFormat, PositionFormat.Full)
+
   def create(throwableFormat: ThrowableFormat, positionFormat: PositionFormat): OFormatter = {
     implicit val encoder: Encoder[LoggerMessage] = loggerMessageEncoder(throwableFormat, positionFormat)
     (msg: LoggerMessage) => msg.asJson.noSpaces

--- a/json/src/main/scala/io/odin/json/Formatter.scala
+++ b/json/src/main/scala/io/odin/json/Formatter.scala
@@ -6,28 +6,27 @@ import io.circe.Encoder
 import io.odin.LoggerMessage
 import io.odin.formatter.{Formatter => OFormatter}
 import io.odin.formatter.Formatter._
-import io.odin.formatter.options.ThrowableFormat
-import perfolation._
+import io.odin.formatter.options.{PositionFormat, ThrowableFormat}
 
 object Formatter {
 
-  val json: OFormatter = create(ThrowableFormat.Default)
+  val json: OFormatter = create(ThrowableFormat.Default, PositionFormat.Full)
 
-  def create(throwableFormat: ThrowableFormat): OFormatter = {
-    implicit val encoder: Encoder[LoggerMessage] = loggerMessageEncoder(throwableFormat)
+  def create(throwableFormat: ThrowableFormat, positionFormat: PositionFormat): OFormatter = {
+    implicit val encoder: Encoder[LoggerMessage] = loggerMessageEncoder(throwableFormat, positionFormat)
     (msg: LoggerMessage) => msg.asJson.noSpaces
   }
 
-  def loggerMessageEncoder(throwableFormat: ThrowableFormat): Encoder[LoggerMessage] =
+  def loggerMessageEncoder(throwableFormat: ThrowableFormat, positionFormat: PositionFormat): Encoder[LoggerMessage] =
     Encoder.forProduct7("level", "message", "context", "exception", "position", "thread_name", "timestamp")(m =>
       (
         m.level.show,
         m.message.value,
         m.context,
         m.exception.map(t => formatThrowable(t, throwableFormat)),
-        p"${m.position.enclosureName}:${m.position.line}",
+        formatPosition(m.position, positionFormat),
         m.threadName,
-        p"${m.timestamp.t.F}T${m.timestamp.t.T}"
+        formatTimestamp(m.timestamp)
       )
     )
 


### PR DESCRIPTION
This PR brings an additional way to configure the format of the position. (scope of #80)

## Benchmarks 

### Master

| Benchmark                                           | Mode |  Cnt |      Score  |    Error  | Units |
|----------------------------------------------------|------|-----|------------|-------------|-------|
| FormatterBenchmarks.defaultColorful                | avgt |  25 |  8130.564 | ± 7511.598 |  ns/op |
| FormatterBenchmarks.defaultFormatter               | avgt |  25 |  3827.164 | ±  266.007 |  ns/op |
| FormatterBenchmarks.defaultFormatterNoCtx          | avgt |  25 |  3673.840 | ±  154.153 |  ns/op |
| FormatterBenchmarks.defaultFormatterNoCtxThrowable | avgt |  25 |   537.797 | ±   13.598 |  ns/op |
| FormatterBenchmarks.depthFormatter                 | avgt |  25 |  1106.039 | ±  107.574 |  ns/op |
| FormatterBenchmarks.depthIndentFormatter           | avgt |  25 |  1197.449 | ±   88.011 |  ns/op |
| FormatterBenchmarks.jsonFormatter                  | avgt |  25 | 13811.366 | ±  603.861 |  ns/op |

### Position format

| Benchmark                                           | Mode |  Cnt |      Score  |    Error  | Units |
|----------------------------------------------------|------|-----|------------|-------------|-------|
| FormatterBenchmarks.abbreviatedPositionFormatter   | avgt |  25 | 10586.138 | ± 4255.005 | ns/op |
| FormatterBenchmarks.defaultColorful                | avgt |  25 |  7760.048 | ± 3795.697 | ns/op |
| FormatterBenchmarks.defaultFormatter               | avgt |  25 |  3609.332 | ±  510.637 | ns/op |
| FormatterBenchmarks.defaultFormatterNoCtx          | avgt |  25 |  3250.578 | ±   94.497 | ns/op |
| FormatterBenchmarks.defaultFormatterNoCtxThrowable | avgt |  25 |   508.383 | ±   34.270 | ns/op |
| FormatterBenchmarks.depthFormatter                 | avgt |  25 |   986.337 | ±   32.192 | ns/op |
| FormatterBenchmarks.depthIndentFormatter           | avgt |  25 |  1038.359 | ±   25.021 | ns/op |
| FormatterBenchmarks.jsonFormatter                  | avgt |  25 | 13990.842 | ± 1054.441 | ns/op |

