### PR TITLE
Use correct version of ScalaTest module for ScalaCheck

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 lazy val versions = new {
   val scalaTest = "3.1.1"
-  val scalaTestScalaCheck = "3.2.0.1-M2"
+  val scalaTestScalaCheck = "3.1.1.1"
   val cats = "2.1.1"
   val catsEffect = "2.0.0"
   val catsMtl = "0.7.0"


### PR DESCRIPTION
Version `3.2.0.1-M2` is for ScalaTest v3.2.0-M2 which does not maintain binary compatibility with 3.1.x series