### PR TITLE
Add an annotation to hash field values when rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -706,6 +706,13 @@ Replaces the value of an annotated member with `<secret>` :
 case class ApiConfig(uri: String, @secret apiKey: String)
 ```
 
+* @hash
+
+Replaces the value of an annotated member with its SHA-256 hash:
+```scala
+case class ApiConfig(uri: String, @hash apiKey: String)
+```
+
 * @length
 
 Shows only first N elements of the iterable. Works exclusively with subtypes of `Iterable`:

--- a/extras/src/main/scala/io/odin/extras/derivation/annotations.scala
+++ b/extras/src/main/scala/io/odin/extras/derivation/annotations.scala
@@ -6,6 +6,8 @@ final case class rendered(includeMemberName: Boolean) extends Annotation
 
 final case class secret() extends Annotation
 
+final case class hash() extends Annotation
+
 final case class hidden() extends Annotation
 
 final case class length(max: Int) extends Annotation

--- a/extras/src/main/scala/io/odin/extras/derivation/render.scala
+++ b/extras/src/main/scala/io/odin/extras/derivation/render.scala
@@ -113,7 +113,7 @@ private object RenderUtils {
   def sha256(value: String): String = {
     val digest = MessageDigest.getInstance("SHA-256")
     digest.update(value.getBytes(java.nio.charset.StandardCharsets.UTF_8))
-    String.format("%040x", new BigInteger(1, digest.digest()))
+    String.format("%064x", new BigInteger(1, digest.digest()))
   }
 
   object hasLengthLimit {

--- a/extras/src/test/scala/io/odin/extras/derivation/RenderDerivationSpec.scala
+++ b/extras/src/test/scala/io/odin/extras/derivation/RenderDerivationSpec.scala
@@ -22,6 +22,16 @@ class RenderDerivationSpec extends OdinSpec {
     Render[WithSecret[String, String]].render(instance) shouldBe expected
   }
 
+  it should "hash fields with @hash annotation" in {
+    val instance = WithHashed("my-field", 123.4)
+
+    // The expected hash was generated using:
+    // echo -n '123.4' | shasum -a 256
+    val expected = "WithHashed(field = my-field, hashed (sha256 hash) = 5f466d7afa48b619c7045d54b15d8d48f47e401335078e9267f5e1d942e09ca5)"
+
+    Render[WithHashed[String, Double]].render(instance) shouldBe expected
+  }
+
   it should "show limited number of elements with @length annotation" in {
     val instance = WithLengthLimit("my-field", List(1, 2, 3, 4, 5))
     val expected = "WithLengthLimit(field = my-field, limited = List(1, 2, 3)(2 more))"
@@ -106,6 +116,8 @@ object RenderDerivationSpec {
   final case class WithHidden[A, B](field: A, @hidden hidden: B)
 
   final case class WithSecret[A, B](field: A, @secret secret: B)
+
+  final case class WithHashed[A, B](field: A, @hash hashed: B)
 
   final case class WithLengthLimit[A, B](field: A, @length(LengthLimit) limited: B)
 


### PR DESCRIPTION
This is useful because you avoid logging sensitive data in plaintext but you can still search for known values in the logs.