### PR TITLE
Typed and nested context with generic derivation

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -97,14 +97,11 @@ lazy val sharedSettings = Seq(
 lazy val `odin-core` = (project in file("core"))
   .settings(sharedSettings)
   .settings(
-    libraryDependencies ++= (monix % Test) :: catsMtl :: sourcecode :: monixCatnap :: perfolation :: cats
+    libraryDependencies ++= (monix % Test) :: catsMtl :: sourcecode :: monixCatnap :: perfolation :: circeCore :: cats
   )
 
 lazy val `odin-json` = (project in file("json"))
   .settings(sharedSettings)
-  .settings(
-    libraryDependencies += circeCore
-  )
   .dependsOn(`odin-core`)
 
 lazy val `odin-zio` = (project in file("zio"))

--- a/core/src/main/scala/io/odin/meta/ContextData.scala
+++ b/core/src/main/scala/io/odin/meta/ContextData.scala
@@ -1,0 +1,26 @@
+package io.odin.meta
+
+import io.circe.{Encoder, Json, JsonObject}
+import io.circe.syntax._
+
+sealed trait ContextData
+
+final case class ContextMap(map: Map[String, ContextData]) extends ContextData
+final case class ContextList(list: List[ContextData]) extends ContextData
+final case class ContextStringValue(value: String) extends ContextData
+final case class ContextLongValue(value: Long) extends ContextData
+final case class ContextDoubleValue(value: Double) extends ContextData
+final case class ContextBooleanValue(value: Boolean) extends ContextData
+
+object ContextData {
+
+  implicit val jsonEncoder: Encoder[ContextData] = Encoder.instance[ContextData](_ match {
+    case ContextMap(map) => Json.fromJsonObject(JsonObject.fromMap(map.view.mapValues(_.asJson).toMap))
+    case ContextList(list) => Json.fromValues(list.map(_.asJson))
+    case ContextStringValue(value) => Json.fromString(value)
+    case ContextLongValue(value) => Json.fromLong(value)
+    case ContextDoubleValue(value) => Json.fromDoubleOrString(value)
+    case ContextBooleanValue(value) => Json.fromBoolean(value)
+  })
+
+}

--- a/core/src/main/scala/io/odin/meta/ToContextData.scala
+++ b/core/src/main/scala/io/odin/meta/ToContextData.scala
@@ -1,0 +1,53 @@
+package io.odin.meta
+
+import java.util.UUID
+
+trait ToContextData[A] {
+  def toContextData(a: A): ContextData
+}
+
+object ToContextData {
+
+  def apply[A](implicit tcd: ToContextData[A]): ToContextData[A] = tcd
+
+  /**
+    * Construct [[ToContextData]] using default `.toString` method
+    */
+  def fromToString[M]: ToContextData[M] = (m: M) => ContextStringValue(m.toString)
+
+  implicit val toContextDataString: ToContextData[String] =
+    (m: String) => ContextStringValue(m)
+
+  implicit val toContextDataByte: ToContextData[Byte] =
+    (x: Byte) => ContextLongValue(x.toLong)
+
+  implicit val toContextDataShort: ToContextData[Short] =
+    (x: Short) => ContextLongValue(x.toLong)
+
+  implicit val toContextDataInt: ToContextData[Int] =
+    (x: Int) => ContextLongValue(x.toLong)
+
+  implicit val toContextDataLong: ToContextData[Long] =
+    (x: Long) => ContextLongValue(x)
+
+  implicit val toContextDataDouble: ToContextData[Double] =
+    (x: Double) => ContextDoubleValue(x)
+
+  implicit val toContextDataFloat: ToContextData[Float] =
+    (x: Float) => ContextDoubleValue(x.toDouble)
+
+  implicit val toContextDataBoolean: ToContextData[Boolean] =
+    (x: Boolean) => ContextBooleanValue(x)
+
+  implicit val toContextDataUuid: ToContextData[UUID] = fromToString
+
+  implicit def toContextDataList[A](implicit tcd: ToContextData[A]): ToContextData[List[A]] =
+    (list: List[A]) => ContextList(list.map(x => tcd.toContextData(x)))
+
+  // TODO Seq, Vector, NEL
+
+  implicit def toContextDataMap[A](implicit tcd: ToContextData[A]): ToContextData[Map[String, A]] =
+    (map: Map[String, A]) => ContextMap(map.view.mapValues(x => tcd.toContextData(x)).toMap)
+
+}
+

--- a/core/src/test/scala/io/odin/meta/ContextDataSpec.scala
+++ b/core/src/test/scala/io/odin/meta/ContextDataSpec.scala
@@ -1,0 +1,41 @@
+package io.odin.meta
+
+import io.odin.OdinSpec
+
+class ContextDataSpec extends OdinSpec {
+
+  it should "convert to a Map[String, String]" in {
+    val data =
+      ContextMap(Map(
+        "a" -> ContextStringValue("hello"),
+        "b" -> ContextLongValue(123L),
+        "c" -> ContextDoubleValue(4.56),
+        "d" -> ContextBooleanValue(true),
+        "e" -> ContextList(List(
+          ContextStringValue("world"),
+          ContextLongValue(789L),
+          ContextDoubleValue(6.54),
+          ContextBooleanValue(false),
+          ContextMap(Map(
+            "a" -> ContextStringValue("wow"),
+            "b" -> ContextLongValue(1234L),
+            "c" -> ContextDoubleValue(4.32)))))))
+
+    val expected = Map(
+      "a" -> "hello",
+      "b" -> "123",
+      "c" -> "4.56",
+      "d" -> "true",
+      "e.0" -> "world",
+      "e.1" -> "789",
+      "e.2" -> "6.54",
+      "e.3" -> "false",
+      "e.4.a" -> "wow",
+      "e.4.b" -> "1234",
+      "e.4.c" -> "4.32"
+    )
+
+    ContextData.contextData2stringStringMap(data) shouldBe expected
+  }
+
+}

--- a/extras/src/main/scala/io/odin/extras/derivation/context.scala
+++ b/extras/src/main/scala/io/odin/extras/derivation/context.scala
@@ -1,0 +1,78 @@
+package io.odin.extras.derivation
+
+import io.odin.meta._
+import magnolia.{CaseClass, Magnolia, Param, SealedTrait}
+
+object context {
+
+  type Typeclass[A] = ToContextData[A]
+
+  def combine[A](ctx: CaseClass[Typeclass, A]): Typeclass[A] = value => {
+    if (ctx.isValueClass) {
+      ctx.parameters.headOption.fold[ContextData](ContextMap(Map.empty))(param =>
+          param.typeclass.toContextData(param.dereference(value)))
+    } else {
+      val params = ctx.parameters
+        .filterNot(ContextUtils.isHidden)
+        .collect {
+          case param if ContextUtils.isSecret(param) =>
+            (param.label, ContextStringValue(ContextUtils.SecretPlaceholder))
+
+          // TODO does it make sense to support the @length param?
+
+          case param =>
+            (param.label, param.typeclass.toContextData(param.dereference(value)))
+        }
+        .toMap
+      ContextMap(params)
+    }
+  }
+
+  def dispatch[A](ctx: SealedTrait[Typeclass, A]): Typeclass[A] = value => {
+    ctx.dispatch(value)(sub => sub.typeclass.toContextData(sub.cast(value)))
+  }
+
+  /**
+    * Creates an instance for a concrete type. Does not generate instances for underlying types.
+    *
+    * Example:
+    * {{{
+    *   import io.odin.extras.derivation.context
+    *
+    *   case class A(field: String)
+    *   case class B(field: A)
+    *
+    *   val instanceA: ToContextData[A] = context.instance[A] // compiles
+    *   val instanceB: ToContextData[B] = context.instance[B] // does not compile
+    * }}}
+    */
+  def instance[A]: Typeclass[A] = macro Magnolia.gen[A]
+
+  /**
+    * Creates an instance for a concrete type. Recursively generate instances for underlying types.
+    *
+    * Example:
+    * {{{
+    *   import io.odin.extras.derivation.context
+    *
+    *   case class A(field: String)
+    *   case class B(field: A)
+    *
+    *   val instanceB: ToContextData[B] = context.derive[B]
+    * }}}
+    */
+  implicit def derive[A]: Typeclass[A] = macro Magnolia.gen[A]
+
+}
+
+private object ContextUtils {
+
+  val SecretPlaceholder = "<secret>"
+
+  @inline def isSecret[A](param: Param[ToContextData, A]): Boolean =
+    param.annotations.contains(secret())
+
+  @inline def isHidden[A](param: Param[ToContextData, A]): Boolean =
+    param.annotations.contains(hidden())
+
+}

--- a/extras/src/test/scala/io/odin/extras/derivation/ToContextDataDerivationSpec.scala
+++ b/extras/src/test/scala/io/odin/extras/derivation/ToContextDataDerivationSpec.scala
@@ -1,0 +1,132 @@
+package io.odin.extras.derivation
+
+import io.odin.meta.{Foo => _, _}
+import io.odin.OdinSpec
+import io.odin.extras.derivation.ToContextDataDerivationSpec._
+import io.odin.extras.derivation.context._
+import org.scalacheck.{Arbitrary, Gen}
+
+class ToContextDataDerivationSpec extends OdinSpec {
+
+  it should "hide fields with @hidden annotation" in {
+    val instance = WithHidden("my-field", 42)
+    val expected = ContextMap(Map("field" -> ContextStringValue("my-field")))
+
+    ToContextData[WithHidden[String, Int]].toContextData(instance) shouldBe expected
+  }
+
+  it should "mask fields with @secret annotation" in {
+    val instance = WithSecret("my-field", "api-key")
+    val expected = ContextMap(Map(
+      "field" -> ContextStringValue("my-field"),
+      "secret" -> ContextStringValue("<secret>"),
+    ))
+
+    ToContextData[WithSecret[String, String]].toContextData(instance) shouldBe expected
+  }
+
+  //it should "show limited number of elements with @length annotation" in {
+  //  val instance = WithLengthLimit("my-field", List(1, 2, 3, 4, 5))
+  //  val expected = "WithLengthLimit(field = my-field, limited = List(1, 2, 3)(2 more))"
+
+  //  ToContextData[WithLengthLimit[String, List[Int]]].render(instance) shouldBe expected
+  //}
+
+  //it should "ignore @length annotation when annotated type is not a subtype of Iterable" in {
+  //  val instance = WithLengthLimit("my-field", "api-key")
+  //  val expected = "WithLengthLimit(field = my-field, limited = api-key)"
+
+  //  ToContextData[WithLengthLimit[String, String]].render(instance) shouldBe expected
+  //}
+
+  it should "derive a type class respecting annotations" in forAll { bar: Bar =>
+    def fooToContextData(foo: Foo): ContextData =
+      ContextMap(Map(
+        "field" -> ContextMap(Map(
+          "field" -> ContextLongValue(foo.field.field.value.toLong),
+          "secret" -> ContextStringValue("<secret>"),
+          "anotherField" -> ContextDoubleValue(foo.field.anotherField)
+        ))
+      ))
+
+    val generic =
+      ContextMap(Map(
+        "field" -> ContextStringValue(bar.genericClass.field),
+        "secret" -> ContextStringValue("<secret>"),
+        "anotherField" -> ContextList(bar.genericClass.anotherField.map(fooToContextData))
+      ))
+
+    val expected = ContextMap(Map("genericClass" -> generic))
+
+    ToContextData[Bar].toContextData(bar) shouldBe expected
+  }
+
+  it should "not recursively generate instances by `instance` method" in {
+    assertDoesNotCompile {
+      """
+        case class A(field: String)
+        case class B(field: A)
+        io.odin.extras.derivation.context.instance[B]
+      """
+    }
+  }
+
+  it should "recursively generate instances by `derive` method" in {
+    assertCompiles {
+      """
+        case class A(field: String)
+        case class B(field: A)
+        io.odin.extras.derivation.context.derive[B]
+      """
+    }
+  }
+
+  val valueClassGen: Gen[ValueClass] =
+    for {
+      int <- Gen.posNum[Int]
+    } yield ValueClass(int)
+
+  val fooGen: Gen[Foo] =
+    for {
+      field <- valueClassGen
+      hidden <- Gen.negNum[Long]
+      secret <- nonEmptyStringGen
+      anotherField <- Gen.posNum[Double]
+    } yield Foo(GenericClass(field, hidden, secret, anotherField))
+
+  val barGen: Gen[Bar] =
+    for {
+      field <- nonEmptyStringGen
+      hidden <- valueClassGen
+      secret <- Gen.listOf(nonEmptyStringGen)
+      anotherField <- Gen.listOf(fooGen)
+    } yield Bar(GenericClass(field, hidden, secret, anotherField))
+
+  implicit val barArbitrary: Arbitrary[Bar] = Arbitrary(barGen)
+
+}
+
+object ToContextDataDerivationSpec {
+
+  val LengthLimit: Int = 3
+
+  final case class WithHidden[A, B](field: A, @hidden hidden: B)
+
+  final case class WithSecret[A, B](field: A, @secret secret: B)
+
+  final case class WithLengthLimit[A, B](field: A, @length(LengthLimit) limited: B)
+
+  final case class GenericClass[A, B, C, D](
+      field: A,
+      @hidden hidden: B,
+      @secret secret: C,
+      anotherField: D
+  )
+
+  final case class ValueClass(value: Int) extends AnyVal
+
+  final case class Foo(field: GenericClass[ValueClass, Long, String, Double])
+
+  final case class Bar(genericClass: GenericClass[String, ValueClass, List[String], List[Foo]])
+
+}


### PR DESCRIPTION
This PR introduces:

* a JSON-like `ContextData` ADT to allow richer context information to be added to logs.
* a `ToContextData` type class for converting things to `ContextData`
* Magnolia generic derivation of `ToContextData` instances for case classes

This is maybe not such an interesting feature for the built-in console and file loggers, but it would be useful for e.g. a logger that sends logs to Logstash via TCP/UDP. Logstash supports arbitrary JSON context in logs.

The generic derivation supports the `hidden` and `secret` annotations, so I would count this as a fix for #68. (Note: I'm the guy who originally suggested #68 on Twitter 😄 )

Ideally I'd like to change the method signatures of `Logger.trace/debug/info/error/warn` to take a `C: ToContextData` instead of a `Map[String, String]`. I'd also like to change the type of `LoggerMessage.context` from `Map[String, String]` to `ContextData`. But these are very invasive changes, so I'd like to hear your thoughts before I proceed any further.

If we made those changes, I suggest the console and file loggers should render the context as JSON. e.g. instead of:

```
2020-05-06T21:34:53,223 [run-main-0] INFO repl.Session.App#res13:265 - Hello world - env: ctx
```

a log would look like:

```
2020-05-06T21:34:53,223 [run-main-0] INFO repl.Session.App#res13:265 - Hello world - { "env": 
 "ctx" }
```

I've defined a circe `Encoder` in preparation for that.

For now, to avoid having to make any changes to `Logger` or `LoggerMessage`, I've added an implicit conversion from `ContextData` to `Map[String, String]`.

What do you think? Is there any interest in this feature?