### PR TITLE
Update cats-mtl to 1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -505,12 +505,11 @@ Odin allows to build a logger that extracts this information from effect and put
 ```scala
 import io.odin.loggers._
 import cats.data.ReaderT
-import cats.mtl.instances.all._ //provides ApplicativeAsk instance for ReaderT //provides ApplicativeAsk instance for ReaderT
 
 case class Env(ctx: Map[String, String])
 
 object Env {
-  //it's neccessary to describe how to extract context from env
+  //it's necessary to describe how to extract context from env
   implicit val hasContext: HasContext[Env] = new HasContext[Env] {
     def getContext(env: Env): Map[String, String] = env.ctx
   }
@@ -526,7 +525,7 @@ consoleLogger[M]()
 // 2020-08-13T11:20:18,305 [run-main-0] INFO repl.MdocSession.App#res13:264 - Hello world - env: ctx
 ```
 
-Odin automatically derives required type classes for each type `F[_]` that has `ApplicativeAsk[F, E]` defined, or in other words
+Odin automatically derives required type classes for each type `F[_]` that has `Ask[F, E]` defined, or in other words
 for all the types that allow `F[A] => F[E]`.
 
 If this constraint isn't satisfied, it's required to manually provide an instance for `WithContext` type class:  

--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ lazy val versions = new {
   val scalaTestScalaCheck = "3.2.0.0"
   val cats = "2.2.0"
   val catsEffect = "2.2.0"
-  val catsMtl = "0.7.1"
+  val catsMtl = "1.0.0"
   val sourcecode = "0.2.1"
   val monix = "3.2.2"
   val magnolia = "0.17.0"
@@ -30,7 +30,7 @@ lazy val cats = List(
 
 lazy val catsEffect = "org.typelevel" %% "cats-effect" % versions.catsEffect
 
-lazy val catsMtl = "org.typelevel" %% "cats-mtl-core" % versions.catsMtl
+lazy val catsMtl = "org.typelevel" %% "cats-mtl" % versions.catsMtl
 
 lazy val sourcecode = "com.lihaoyi" %% "sourcecode" % versions.sourcecode
 

--- a/core/src/main/scala/io/odin/loggers/ContextualLogger.scala
+++ b/core/src/main/scala/io/odin/loggers/ContextualLogger.scala
@@ -2,7 +2,7 @@ package io.odin.loggers
 
 import cats.Monad
 import cats.effect.Clock
-import cats.mtl.ApplicativeAsk
+import cats.mtl.Ask
 import cats.syntax.all._
 import io.odin.{Logger, LoggerMessage}
 
@@ -47,11 +47,11 @@ trait WithContext[F[_]] {
 object WithContext {
 
   /**
-    * Default implementation of `WithContext` that works for any `F[_]` with `ApplicativeAsk` instance and
-    * instance of [[HasContext]] for environment of this `ApplicativeAsk`
+    * Default implementation of `WithContext` that works for any `F[_]` with `Ask` instance and
+    * instance of [[HasContext]] for environment of this `Ask`
     */
   implicit def fromHasContext[F[_], Env](
-      implicit A: ApplicativeAsk[F, Env],
+      implicit A: Ask[F, Env],
       hasContext: HasContext[Env],
       F: Monad[F]
   ): WithContext[F] = new WithContext[F] {

--- a/core/src/test/scala/io/odin/loggers/ContextualLoggerSpec.scala
+++ b/core/src/test/scala/io/odin/loggers/ContextualLoggerSpec.scala
@@ -3,7 +3,6 @@ package io.odin.loggers
 import cats.arrow.FunctionK
 import cats.data.{ReaderT, WriterT}
 import cats.effect.{Clock, IO}
-import cats.mtl.instances.all._
 import io.odin.syntax._
 import io.odin.{LoggerMessage, OdinSpec}
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -488,12 +488,11 @@ Odin allows to build a logger that extracts this information from effect and put
 ```scala mdoc
 import io.odin.loggers._
 import cats.data.ReaderT
-import cats.mtl.instances.all._ //provides ApplicativeAsk instance for ReaderT
 
 case class Env(ctx: Map[String, String])
 
 object Env {
-  //it's neccessary to describe how to extract context from env
+  //it's necessary to describe how to extract context from env
   implicit val hasContext: HasContext[Env] = new HasContext[Env] {
     def getContext(env: Env): Map[String, String] = env.ctx
   }
@@ -508,7 +507,7 @@ consoleLogger[M]()
     .unsafeRunSync()
 ```
 
-Odin automatically derives required type classes for each type `F[_]` that has `ApplicativeAsk[F, E]` defined, or in other words
+Odin automatically derives required type classes for each type `F[_]` that has `Ask[F, E]` defined, or in other words
 for all the types that allow `F[A] => F[E]`.
 
 If this constraint isn't satisfied, it's required to manually provide an instance for `WithContext` type class:  
@@ -523,7 +522,7 @@ trait WithContext[F[_]] {
 
 ## Secret Context
 
-Sometimes it's neccessary to hide sensitive information from the logs, would it be user identification data, passwords or
+Sometimes it's necessary to hide sensitive information from the logs, would it be user identification data, passwords or
 anything else.
 
 Odin can hash the values of predefined context keys to preserve the fact of information existence, but exact value

--- a/examples/src/main/scala/io/odin/examples/WithContextual.scala
+++ b/examples/src/main/scala/io/odin/examples/WithContextual.scala
@@ -3,7 +3,6 @@ package io.odin.examples
 import cats.data.ReaderT
 import cats.effect.{ExitCode, IO, IOApp}
 import io.odin._
-import cats.mtl.instances.all._
 import io.odin.formatter.Formatter
 import io.odin.loggers.HasContext
 import io.odin.syntax._
@@ -11,7 +10,7 @@ import io.odin.syntax._
 /**
   * Prints `Hello World` log line with some context picked up from the environment of `F[_]`
   *
-  * In cases when there is `ApplicativeAsk[F, Env]` available in scope, and there is type class [[HasContext]] for
+  * In cases when there is `Ask[F, Env]` available in scope, and there is type class [[HasContext]] for
   * environment `Env` defined, `withContext` will automatically derive required type classes for adding the context to
   * the log
   */
@@ -25,13 +24,11 @@ object WithContextual extends IOApp {
   /**
     * Define how to pick the context out of [[F]] environment. Here it's just identity
     */
-  implicit val hasContext: HasContext[Map[String, String]] = new HasContext[Map[String, String]] {
-    def getContext(env: Map[String, String]): Map[String, String] = env
-  }
+  implicit val hasContext: HasContext[Map[String, String]] = (env: Map[String, String]) => env
 
   /**
-    * `withContext` requires `WithContext[F]` type class but with `import cats.mtl.instances.all._` that provides
-    * `ApplicativeAsk[F, Env]` and corresponding `HasContext` instance defined, this type class is derived automatically
+    * `withContext` requires `WithContext[F]` type class but with the corresponding `HasContext` instance defined,
+    * this type class is derived automatically
     */
   val logger: Logger[F] = consoleLogger[F](formatter = Formatter.colorful).withContext
 

--- a/extras/src/test/scala/io/odin/extras/loggers/ConditionalLoggerSpec.scala
+++ b/extras/src/test/scala/io/odin/extras/loggers/ConditionalLoggerSpec.scala
@@ -3,7 +3,6 @@ package io.odin.extras.loggers
 import cats.data.Kleisli
 import cats.effect.Sync
 import cats.effect.concurrent.Ref
-import cats.mtl.instances.all._
 import cats.syntax.applicativeError._
 import cats.syntax.flatMap._
 import cats.syntax.order._


### PR DESCRIPTION
This PR brings an update to the most recent release of the cats-mtl.  
Unfortunately, this change breaks binary compatibility for the future release. 