### PR TITLE
Fix typo: binder instead of builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -807,7 +807,7 @@ class ExternalLogger extends OdinLoggerBinder[IO] {
 }
 ```
 
-- Create `StaticLoggerBuilder.java` class in the package `org.slf4j.impl` with the following content:
+- Create `StaticLoggerBinder.java` class in the package `org.slf4j.impl` with the following content:
 ```java
 package org.slf4j.impl;
 


### PR DESCRIPTION
First of all, what a wondefull library.

I just found a small typographical error in the `SLF4J bridge` section when I was trying to use the code. Btw, the code is working perfectly with http4s 👍🏻.