### PR TITLE
WIP: CE 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ import cats.effect.IO
 import cats.effect.unsafe.IORuntime
 
 //required for evaluation of IO later. IOApp provides it out of the box
+//or it can be imported by `import cats.effect.unsafe.implicits._`
 implicit val ioRuntime: IORuntime = IORuntime.global
 
 val logger: Logger[IO] = consoleLogger[IO]()

--- a/benchmarks/src/main/scala/io/odin/Benchmarks.scala
+++ b/benchmarks/src/main/scala/io/odin/Benchmarks.scala
@@ -5,7 +5,8 @@ import java.util.UUID
 import java.util.concurrent.TimeUnit
 
 import cats.Eval
-import cats.effect.{ContextShift, IO, Timer}
+import cats.effect.IO
+import cats.effect.unsafe.IORuntime
 import io.odin
 import io.odin.loggers.DefaultLogger
 import io.odin.syntax._
@@ -46,9 +47,7 @@ abstract class OdinBenchmarks {
     "just-a-test-thread",
     1574716305L
   )
-
-  implicit val timer: Timer[IO] = IO.timer(scala.concurrent.ExecutionContext.global)
-  implicit val contextShift: ContextShift[IO] = IO.contextShift(scala.concurrent.ExecutionContext.global)
+  implicit val ioRuntime: IORuntime = IORuntime.global
 }
 
 @State(Scope.Benchmark)

--- a/benchmarks/src/main/scala/io/odin/Benchmarks.scala
+++ b/benchmarks/src/main/scala/io/odin/Benchmarks.scala
@@ -7,6 +7,7 @@ import java.util.concurrent.TimeUnit
 import cats.Eval
 import cats.effect.IO
 import cats.effect.unsafe.IORuntime
+import cats.syntax.traverse._
 import io.odin
 import io.odin.loggers.DefaultLogger
 import io.odin.syntax._
@@ -82,17 +83,17 @@ class FileLoggerBenchmarks extends OdinBenchmarks {
   @Benchmark
   @OperationsPerInvocation(1000)
   def msg(): Unit =
-    for (_ <- 1 to 1000) logger.info(message).unsafeRunSync()
+    (1 to 1000).toList.traverse(_ => logger.info(message)).unsafeRunSync()
 
   @Benchmark
   @OperationsPerInvocation(1000)
   def msgAndCtx(): Unit =
-    for (_ <- 1 to 1000) logger.info(message, context).unsafeRunSync()
+    (1 to 1000).toList.traverse(_ => logger.info(message, context)).unsafeRunSync()
 
   @Benchmark
   @OperationsPerInvocation(1000)
   def msgCtxThrowable(): Unit =
-    for (_ <- 1 to 1000) logger.info(message, context, throwable).unsafeRunSync()
+    (1 to 1000).toList.traverse(_ => logger.info(message, context, throwable)).unsafeRunSync()
 
   @TearDown
   def tearDown(): Unit = {
@@ -184,17 +185,17 @@ class AsyncLoggerBenchmark extends OdinBenchmarks {
 
   @Benchmark
   @OperationsPerInvocation(1000)
-  def msg(): Unit = for (_ <- 1 to 1000) asyncLogger.info(message).unsafeRunSync()
+  def msg(): Unit = (1 to 1000).toList.traverse(_ => asyncLogger.info(message)).unsafeRunSync()
 
   @Benchmark
   @OperationsPerInvocation(1000)
   def msgAndCtx(): Unit =
-    for (_ <- 1 to 1000) asyncLogger.info(message, context).unsafeRunSync()
+    (1 to 1000).toList.traverse(_ => asyncLogger.info(message, context)).unsafeRunSync()
 
   @Benchmark
   @OperationsPerInvocation(1000)
   def msgCtxThrowable(): Unit =
-    for (_ <- 1 to 1000) asyncLogger.info(message, context, throwable).unsafeRunSync()
+    (1 to 1000).toList.traverse(_ => asyncLogger.info(message, context, throwable)).unsafeRunSync()
 
   @TearDown
   def tearDown(): Unit = {

--- a/benchmarks/src/main/scala/io/odin/Test.scala
+++ b/benchmarks/src/main/scala/io/odin/Test.scala
@@ -1,0 +1,24 @@
+package io.odin
+
+import java.nio.file.{Files, Paths}
+import java.util.UUID
+
+import cats.effect.{IO, IOApp}
+import cats.syntax.all._
+import io.odin.syntax._
+
+object Test extends IOApp.Simple {
+
+  val fileName: String = Files.createTempFile(UUID.randomUUID().toString, "").toAbsolutePath.toString
+
+  val message: String = "msg"
+
+  def run: IO[Unit] =
+    fileLogger[IO](fileName)
+      .withAsync(maxBufferSize = Some(1000000))
+      .use { logger =>
+        val io = (1 to 1000).toList.traverse(_ => logger.info(message))
+        io.foreverM
+      }
+      .guarantee(IO.delay(Files.delete(Paths.get(fileName))))
+}

--- a/build.sbt
+++ b/build.sbt
@@ -30,7 +30,6 @@ lazy val cats = List(
 
 lazy val catsEffect = "org.typelevel" %% "cats-effect" % versions.catsEffect
 lazy val catsEffectStd = "org.typelevel" %% "cats-effect-std" % versions.catsEffect
-lazy val catsEffectTestKit = "org.typelevel" %% "cats-effect-testkit" % versions.catsEffect % Test
 
 lazy val catsMtl = "org.typelevel" %% "cats-mtl" % versions.catsMtl
 
@@ -105,7 +104,6 @@ lazy val `odin-core` = (project in file("core"))
       sourcecode,
       //monixCatnap.exclude("org.typelevel", "cats-effect_2.13"),
       perfolation,
-      catsEffectTestKit,
       monix % Test,
       catsEffect % Test
     )

--- a/build.sbt
+++ b/build.sbt
@@ -2,14 +2,14 @@ lazy val versions = new {
   val scalaTest = "3.1.3"
   val scalaTestScalaCheck = "3.2.0.0"
   val cats = "2.3.1"
-  val catsEffect = "3.0.1"
+  val catsEffect = "3.0.2"
   val catsMtl = "1.1.1"
   val sourcecode = "0.2.3"
   val monix = "3.3.0"
   val magnolia = "0.17.0"
   val scalaCheck = "1.15.2"
   val zio = "1.0.4"
-  val zioCats = "2.2.0.1"
+  val zioCats = "3.0.2.0"
   val slf4j = "1.7.30"
   val log4j = "2.14.0"
   val disruptor = "3.4.2"
@@ -112,6 +112,7 @@ lazy val `odin-zio` = (project in file("zio"))
   .settings(sharedSettings)
   .settings(
     libraryDependencies ++= Seq(
+      catsEffect,
       "dev.zio" %% "zio" % versions.zio,
       "dev.zio" %% "zio-interop-cats" % versions.zioCats
     )
@@ -158,7 +159,7 @@ lazy val docs = (project in file("odin-docs"))
     mdocOut := file("."),
     libraryDependencies += catsEffect
   )
-  .dependsOn(`odin-core`, `odin-json`, /*`odin-zio`, `odin-monix`,*/ `odin-slf4j`, `odin-extras`)
+  .dependsOn(`odin-core`, `odin-json`, `odin-zio`, /*`odin-monix`,*/ `odin-slf4j`, `odin-extras`)
   .enablePlugins(MdocPlugin)
 
 lazy val examples = (project in file("examples"))
@@ -168,13 +169,13 @@ lazy val examples = (project in file("examples"))
     libraryDependencies += catsEffect
   )
   .settings(noPublish)
-  .dependsOn(`odin-core` % "compile->compile;test->test"/*, `odin-zio`*/)
+  .dependsOn(`odin-core` % "compile->compile;test->test", `odin-zio`)
 
 lazy val odin = (project in file("."))
   .settings(sharedSettings)
   .settings(noPublish)
-  .dependsOn(`odin-core`, `odin-json`, /*`odin-zio`, `odin-monix`,*/ `odin-slf4j`, `odin-extras`)
-  .aggregate(`odin-core`, `odin-json`, /*`odin-zio`, `odin-monix`,*/ `odin-slf4j`, `odin-extras`, benchmarks, examples)
+  .dependsOn(`odin-core`, `odin-json`, `odin-zio`,/* `odin-monix`,*/ `odin-slf4j`, `odin-extras`)
+  .aggregate(`odin-core`, `odin-json`, `odin-zio`,/* `odin-monix`,*/ `odin-slf4j`, `odin-extras`, benchmarks, examples)
 
 def scalacOptionsVersion(scalaVersion: String) =
   Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -98,15 +98,7 @@ lazy val sharedSettings = Seq(
 lazy val `odin-core` = (project in file("core"))
   .settings(sharedSettings)
   .settings(
-    libraryDependencies ++= cats ++ Seq(
-      catsEffectStd,
-      catsMtl,
-      sourcecode,
-      //monixCatnap.exclude("org.typelevel", "cats-effect_2.13"),
-      perfolation,
-      monix % Test,
-      catsEffect % Test
-    )
+    libraryDependencies ++= (catsEffect % Test) :: catsMtl :: sourcecode :: perfolation :: catsEffectStd :: cats
   )
 
 lazy val `odin-json` = (project in file("json"))

--- a/core/src/main/scala/io/odin/config/DefaultBuilder.scala
+++ b/core/src/main/scala/io/odin/config/DefaultBuilder.scala
@@ -1,10 +1,9 @@
 package io.odin.config
 
-import cats.Monad
-import cats.effect.Clock
+import cats.Applicative
 import io.odin.Logger
 
-class DefaultBuilder[F[_]: Clock: Monad](val withDefault: Logger[F] => Logger[F]) {
+class DefaultBuilder[F[_]: Applicative](val withDefault: Logger[F] => Logger[F]) {
   def withNoopFallback: Logger[F] =
     withDefault(Logger.noop[F])
   def withFallback(fallback: Logger[F]): Logger[F] =

--- a/core/src/main/scala/io/odin/config/EnclosureRouting.scala
+++ b/core/src/main/scala/io/odin/config/EnclosureRouting.scala
@@ -1,7 +1,7 @@
 package io.odin.config
 
 import cats.Monad
-import cats.effect.Clock
+import cats.effect.kernel.Clock
 import cats.syntax.all._
 import io.odin.loggers.DefaultLogger
 import io.odin.{Level, Logger, LoggerMessage}

--- a/core/src/main/scala/io/odin/config/package.scala
+++ b/core/src/main/scala/io/odin/config/package.scala
@@ -3,7 +3,7 @@ package io.odin
 import java.time.LocalDateTime
 
 import cats.Monad
-import cats.effect.Clock
+import cats.effect.kernel.Clock
 import cats.syntax.all._
 import io.odin.internal.StringContextLength
 import io.odin.loggers.DefaultLogger

--- a/core/src/main/scala/io/odin/loggers/AsyncLogger.scala
+++ b/core/src/main/scala/io/odin/loggers/AsyncLogger.scala
@@ -1,6 +1,6 @@
 package io.odin.loggers
 
-import cats.effect.kernel.{Async, Fiber, Outcome, Resource}
+import cats.effect.kernel.{Async, Resource}
 import cats.effect.std.Dispatcher
 import cats.effect.std.Queue
 import cats.syntax.all._

--- a/core/src/main/scala/io/odin/loggers/AsyncLogger.scala
+++ b/core/src/main/scala/io/odin/loggers/AsyncLogger.scala
@@ -14,7 +14,7 @@ import scala.concurrent.duration._
   * Use `AsyncLogger.withAsync` to instantiate it safely
   */
 case class AsyncLogger[F[_]](queue: Queue[F, LoggerMessage], timeWindow: FiniteDuration, inner: Logger[F])(
-    implicit F: Async[F],
+    implicit F: Async[F]
 ) extends DefaultLogger[F](inner.minLevel) {
   def submit(msg: LoggerMessage): F[Unit] = {
     queue.tryOffer(msg).void
@@ -48,7 +48,7 @@ case class AsyncLogger[F[_]](queue: Queue[F, LoggerMessage], timeWindow: FiniteD
     F.tailRecM(Vector.empty[LoggerMessage]) { acc =>
       queue.tryTake.map {
         case Some(value) => Left(acc :+ value)
-        case None => Right(acc)
+        case None        => Right(acc)
       }
     }
 }
@@ -104,6 +104,7 @@ object AsyncLogger {
       timeWindow: FiniteDuration,
       maxBufferSize: Option[Int]
   )(
-      implicit F: Async[F], dispatcher: Dispatcher[F]
+      implicit F: Async[F],
+      dispatcher: Dispatcher[F]
   ): Logger[F] = dispatcher.unsafeRunSync(withAsync(inner, timeWindow, maxBufferSize).allocated)._1
 }

--- a/core/src/main/scala/io/odin/loggers/AsyncLogger.scala
+++ b/core/src/main/scala/io/odin/loggers/AsyncLogger.scala
@@ -21,7 +21,7 @@ case class AsyncLogger[F[_]: Clock](queue: Queue[F, LoggerMessage], timeWindow: 
     queue.tryOffer(msg).void
   }
 
-  private def drain: F[Unit] =
+  private[loggers] def drain: F[Unit] =
     drainAll.flatMap(msgs => inner.log(msgs.toList)).orElse(F.unit)
 
   def withMinimalLevel(level: Level): Logger[F] = copy(inner = inner.withMinimalLevel(level))

--- a/core/src/main/scala/io/odin/loggers/ConsoleLogger.scala
+++ b/core/src/main/scala/io/odin/loggers/ConsoleLogger.scala
@@ -2,12 +2,12 @@ package io.odin.loggers
 
 import java.io.PrintStream
 
-import cats.effect.{Clock, Sync}
+import cats.effect.kernel.Sync
 import cats.syntax.all._
 import io.odin.formatter.Formatter
 import io.odin.{Level, Logger, LoggerMessage}
 
-case class ConsoleLogger[F[_]: Clock](
+case class ConsoleLogger[F[_]](
     formatter: Formatter,
     out: PrintStream,
     err: PrintStream,
@@ -28,6 +28,6 @@ case class ConsoleLogger[F[_]: Clock](
 }
 
 object ConsoleLogger {
-  def apply[F[_]: Clock: Sync](formatter: Formatter, minLevel: Level): Logger[F] =
+  def apply[F[_]: Sync](formatter: Formatter, minLevel: Level): Logger[F] =
     ConsoleLogger(formatter, scala.Console.out, scala.Console.err, minLevel)
 }

--- a/core/src/main/scala/io/odin/loggers/ConstContextLogger.scala
+++ b/core/src/main/scala/io/odin/loggers/ConstContextLogger.scala
@@ -1,7 +1,7 @@
 package io.odin.loggers
 
 import cats.Monad
-import cats.effect.Clock
+import cats.effect.kernel.Clock
 import io.odin.{Level, Logger, LoggerMessage}
 
 case class ConstContextLogger[F[_]: Clock: Monad](ctx: Map[String, String], inner: Logger[F])

--- a/core/src/main/scala/io/odin/loggers/ContextualLogger.scala
+++ b/core/src/main/scala/io/odin/loggers/ContextualLogger.scala
@@ -1,7 +1,7 @@
 package io.odin.loggers
 
 import cats.Monad
-import cats.effect.Clock
+import cats.effect.kernel.Clock
 import cats.mtl.Ask
 import cats.syntax.all._
 import io.odin.{Level, Logger, LoggerMessage}

--- a/core/src/main/scala/io/odin/loggers/ContramapLogger.scala
+++ b/core/src/main/scala/io/odin/loggers/ContramapLogger.scala
@@ -1,7 +1,7 @@
 package io.odin.loggers
 
 import cats.Monad
-import cats.effect.Clock
+import cats.effect.kernel.Clock
 import io.odin.{Level, Logger, LoggerMessage}
 
 /**

--- a/core/src/main/scala/io/odin/loggers/DefaultLogger.scala
+++ b/core/src/main/scala/io/odin/loggers/DefaultLogger.scala
@@ -1,9 +1,7 @@
 package io.odin.loggers
 
-import java.util.concurrent.TimeUnit
-
 import cats.{Eval, Monad}
-import cats.effect.Clock
+import cats.effect.kernel.Clock
 import cats.syntax.all._
 import io.odin.meta.{Position, Render, ToThrowable}
 import io.odin.{Level, Logger, LoggerMessage}
@@ -19,7 +17,7 @@ abstract class DefaultLogger[F[_]](val minLevel: Level)(implicit clock: Clock[F]
       position: Position
   ): F[Unit] =
     for {
-      timestamp <- clock.realTime(TimeUnit.MILLISECONDS)
+      timestamp <- clock.realTime
       _ <- log(
         LoggerMessage(
           level = level,
@@ -28,7 +26,7 @@ abstract class DefaultLogger[F[_]](val minLevel: Level)(implicit clock: Clock[F]
           exception = t,
           position = position,
           threadName = Thread.currentThread().getName,
-          timestamp = timestamp
+          timestamp = timestamp.toMillis
         )
       )
     } yield {

--- a/core/src/main/scala/io/odin/loggers/FilterLogger.scala
+++ b/core/src/main/scala/io/odin/loggers/FilterLogger.scala
@@ -1,7 +1,7 @@
 package io.odin.loggers
 
 import cats.Monad
-import cats.effect.Clock
+import cats.effect.kernel.Clock
 import io.odin.{Level, Logger, LoggerMessage}
 
 /**

--- a/core/src/main/scala/io/odin/loggers/RollingFileLogger.scala
+++ b/core/src/main/scala/io/odin/loggers/RollingFileLogger.scala
@@ -113,7 +113,6 @@ object RollingFileLogger {
           _ <- F.unlessA(checkConditions(start, time, size)) {
             for {
               _ <- F.sleep(100.millis)
-              _ <- F.cede
               _ <- loop(start)
             } yield ()
           }

--- a/core/src/main/scala/io/odin/loggers/RollingFileLogger.scala
+++ b/core/src/main/scala/io/odin/loggers/RollingFileLogger.scala
@@ -1,16 +1,16 @@
 package io.odin.loggers
 
 import java.nio.file.{Files, OpenOption, Path, Paths}
-import java.time.{Instant, LocalDateTime}
-import java.time.format.DateTimeFormatter
+import java.time.LocalDateTime
 import java.util.TimeZone
-import cats.Monad
-import cats.effect.kernel.{Async, Clock, Fiber, Ref, Resource}
+import cats.effect.kernel._
+import cats.effect.std.Hotswap
 import cats.syntax.all._
+import cats.{Functor, Monad}
 import io.odin.formatter.Formatter
 import io.odin.{Level, Logger, LoggerMessage}
 
-import scala.concurrent.duration.{FiniteDuration, _}
+import scala.concurrent.duration._
 
 object RollingFileLogger {
 
@@ -22,15 +22,26 @@ object RollingFileLogger {
       minLevel: Level,
       openOptions: Seq[OpenOption] = Seq.empty
   )(implicit F: Async[F]): Resource[F, Logger[F]] = {
-    new RollingFileLoggerFactory(
-      fileNamePattern,
-      maxFileSizeInBytes,
-      rolloverInterval,
-      formatter,
-      minLevel,
-      FileLogger.apply[F],
-      openOptions = openOptions
-    ).mk
+
+    def rollingLogger =
+      new RollingFileLoggerFactory(
+        fileNamePattern,
+        maxFileSizeInBytes,
+        rolloverInterval,
+        formatter,
+        minLevel,
+        FileLogger.apply[F],
+        openOptions = openOptions
+      ).mk
+
+    def fileLogger =
+      Resource.suspend {
+        for {
+          localTime <- localDateTimeNow
+        } yield FileLogger[F](fileNamePattern(localTime), formatter, minLevel, openOptions)
+      }
+
+    Resource.pure[F, Boolean](maxFileSizeInBytes.isDefined || rolloverInterval.isDefined).ifM(rollingLogger, fileLogger)
   }
 
   private[odin] case class RefLogger[F[_]: Clock: Monad](
@@ -56,32 +67,24 @@ object RollingFileLogger {
       openOptions: Seq[OpenOption]
   )(implicit F: Async[F]) {
 
-    val df: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd-HH-mm-ss")
+    private type RolloverSignal = Deferred[F, Unit]
 
-    def mk: Resource[F, Logger[F]] = {
-      val logger = for {
-        ((logger, watcherFiber), release) <- allocate.allocated
-        refLogger <- Ref.of(logger)
-        refRelease <- Ref.of(release)
-        _ <- F.start(rollingLoop(watcherFiber, refLogger, refRelease))
-      } yield {
-        (RefLogger(refLogger, minLevel), refRelease)
-      }
-      Resource.make(logger)(_._2.get.flatten).map {
-        case (logger, _) => logger
-      }
-    }
+    def mk: Resource[F, Logger[F]] =
+      for {
+        (hs, (logger, rolloverSignal)) <- Hotswap[F, (Logger[F], RolloverSignal)](allocate)
+        refLogger <- Resource.eval(Ref.of(logger))
+        _ <- F.background(rollingLoop(hs, rolloverSignal, refLogger))
+      } yield RefLogger(refLogger, minLevel)
 
-    def now: F[Long] = F.realTime.map(_.toMillis)
+    private def now: F[Long] = F.realTime.map(_.toMillis)
 
     /**
       * Create file logger along with the file watcher
       */
-    def allocate: Resource[F, (Logger[F], Fiber[F, Throwable, Unit])] =
-      Resource.suspend(now.map { time =>
-        val localTime = LocalDateTime.ofInstant(Instant.ofEpochMilli(time), TimeZone.getDefault.toZoneId)
+    private def allocate: Resource[F, (Logger[F], RolloverSignal)] =
+      Resource.suspend(localDateTimeNow.map { localTime =>
         val fileName = fileNamePattern(localTime)
-        underlyingLogger(fileName, formatter, minLevel, openOptions).product(fileWatcher(fileName))
+        underlyingLogger(fileName, formatter, minLevel, openOptions).product(fileWatcher(Paths.get(fileName)))
       })
 
     /**
@@ -90,22 +93,28 @@ object RollingFileLogger {
       * Fiber itself is a file watcher that checks if rollover interval or size are not exceeded and finishes it work
       * the moment at least one of those conditions is met.
       */
-    def fileWatcher(fileName: String): Resource[F, Fiber[F, Throwable, Unit]] = {
-      def checkConditions(start: Long, now: Long, fileSize: Long): Boolean = {
-        (maxFileSizeInBytes match {
-          case Some(max) => fileSize >= max
-          case _         => false
-        }) || (rolloverInterval match {
+    private def fileWatcher(filePath: Path): Resource[F, RolloverSignal] = {
+      val checkFileSize: Long => Boolean =
+        maxFileSizeInBytes match {
+          case Some(max) => fileSize => fileSize >= max
+          case _         => _ => false
+        }
+
+      val checkRolloverInterval: (Long, Long) => Boolean =
+        rolloverInterval match {
           case Some(finite: FiniteDuration) =>
-            start + finite.toMillis <= now
-          case _ => false
-        })
-      }
+            (start, now) => start + finite.toMillis <= now
+          case _ =>
+            (_, _) => false
+        }
+
+      def checkConditions(start: Long, now: Long, fileSize: Long): Boolean =
+        checkFileSize(fileSize) || checkRolloverInterval(start, now)
 
       def loop(start: Long): F[Unit] = {
         for {
           size <- if (maxFileSizeInBytes.isDefined) {
-            F.delay(fileSizeCheck(Paths.get(fileName)))
+            F.delay(fileSizeCheck(filePath))
           } else {
             F.pure(0L)
           }
@@ -119,27 +128,37 @@ object RollingFileLogger {
         } yield ()
       }
 
-      Resource.make[F, Fiber[F, Throwable, Unit]](F.start(now >>= loop))(_.cancel)
+      for {
+        rolloverSignal <- Resource.eval(Deferred[F, Unit])
+        _ <- F.background(now >>= loop >>= rolloverSignal.complete)
+      } yield rolloverSignal
     }
 
     /**
-      * Once watcher fiber is joined, it means that it's triggered and current logger's file exceeded TTL or allowed size.
+      * Once rollover signal is sent, it means that it's triggered and current logger's file exceeded TTL or allowed size.
       * At this moment new logger, new watcher and new release values shall be allocated to replace the old ones.
       *
       * Once new values are allocated and corresponding references are updated, run the old release and loop the whole
       * function using new watcher
       */
-    def rollingLoop(watcher: Fiber[F, Throwable, Unit], logger: Ref[F, Logger[F]], release: Ref[F, F[Unit]]): F[Unit] =
-      for {
-        _ <- watcher.join
-        oldRelease <- release.get
-        ((newLogger, newWatcher), newRelease) <- allocate.allocated
-        _ <- logger.set(newLogger)
-        _ <- release.set(newRelease)
-        _ <- oldRelease
-        _ <- rollingLoop(newWatcher, logger, release)
-      } yield ()
+    private def rollingLoop(
+        hs: Hotswap[F, (Logger[F], RolloverSignal)],
+        rolloverSignal: RolloverSignal,
+        logger: Ref[F, Logger[F]]
+    ): F[Unit] =
+      F.tailRecM[RolloverSignal, Unit](rolloverSignal) { signal =>
+        for {
+          _ <- signal.get
+          (newLogger, newSignal) <- hs.swap(allocate)
+          _ <- logger.set(newLogger)
+        } yield Left(newSignal)
+      }
 
   }
+
+  private def localDateTimeNow[F[_]: Functor](implicit clock: Clock[F]): F[LocalDateTime] =
+    for {
+      time <- clock.realTimeInstant
+    } yield LocalDateTime.ofInstant(time, TimeZone.getDefault.toZoneId)
 
 }

--- a/core/src/main/scala/io/odin/loggers/WriterTLogger.scala
+++ b/core/src/main/scala/io/odin/loggers/WriterTLogger.scala
@@ -2,7 +2,7 @@ package io.odin.loggers
 
 import cats.Monad
 import cats.data.WriterT
-import cats.effect.Clock
+import cats.effect.kernel.Clock
 import io.odin.{Level, Logger, LoggerMessage}
 
 /**

--- a/core/src/main/scala/io/odin/package.scala
+++ b/core/src/main/scala/io/odin/package.scala
@@ -2,8 +2,7 @@ package io
 
 import java.nio.file.OpenOption
 import java.time.LocalDateTime
-
-import cats.effect.{Clock, Concurrent, ContextShift, Resource, Sync, Timer}
+import cats.effect.kernel.{Async, Clock, Resource, Sync}
 import io.odin.formatter.Formatter
 import io.odin.loggers.{ConsoleLogger, FileLogger, RollingFileLogger}
 import io.odin.syntax._
@@ -57,7 +56,7 @@ package object odin {
     * @param formatter formatter to use
     * @param minLevel minimal level of logs to be printed
     */
-  def rollingFileLogger[F[_]: Concurrent: Timer: ContextShift](
+  def rollingFileLogger[F[_]: Async](
       fileNamePattern: LocalDateTime => String,
       rolloverInterval: Option[FiniteDuration],
       maxFileSizeInBytes: Option[Long],
@@ -76,7 +75,7 @@ package object odin {
     * @param maxBufferSize maximum buffer size
     * @param minLevel minimal level of logs to be printed
     */
-  def asyncFileLogger[F[_]: Concurrent: Timer: ContextShift](
+  def asyncFileLogger[F[_]: Async](
       fileName: String,
       formatter: Formatter = Formatter.default,
       timeWindow: FiniteDuration = 1.second,
@@ -98,7 +97,7 @@ package object odin {
     * @param formatter formatter to use
     * @param minLevel minimal level of logs to be printed
     */
-  def asyncRollingFileLogger[F[_]: Concurrent: Timer: ContextShift](
+  def asyncRollingFileLogger[F[_]: Async](
       fileNamePattern: LocalDateTime => String,
       rolloverInterval: Option[FiniteDuration],
       maxFileSizeInBytes: Option[Long],

--- a/core/src/main/scala/io/odin/syntax/package.scala
+++ b/core/src/main/scala/io/odin/syntax/package.scala
@@ -1,7 +1,8 @@
 package io.odin
 
 import cats.Monad
-import cats.effect.{Clock, Concurrent, ConcurrentEffect, ContextShift, Resource, Timer}
+import cats.effect.std.Dispatcher
+import cats.effect.kernel.{Async, Clock, Resource}
 import io.odin.loggers.{AsyncLogger, ConstContextLogger, ContextualLogger, ContramapLogger, FilterLogger, WithContext}
 import io.odin.loggers._
 import io.odin.meta.Render
@@ -35,7 +36,7 @@ package object syntax {
     def withAsync(
         timeWindow: FiniteDuration = 1.millis,
         maxBufferSize: Option[Int] = None
-    )(implicit timer: Timer[F], F: Concurrent[F], contextShift: ContextShift[F]): Resource[F, Logger[F]] =
+    )(implicit F: Async[F]): Resource[F, Logger[F]] =
       AsyncLogger.withAsync(logger, timeWindow, maxBufferSize)
 
     /**
@@ -47,7 +48,7 @@ package object syntax {
     def withAsyncUnsafe(
         timeWindow: FiniteDuration = 1.millis,
         maxBufferSize: Option[Int] = None
-    )(implicit timer: Timer[F], F: ConcurrentEffect[F], contextShift: ContextShift[F]): Logger[F] =
+    )(implicit F: Async[F], dispatcher: Dispatcher[F]): Logger[F] =
       AsyncLogger.withAsyncUnsafe(logger, timeWindow, maxBufferSize)
 
     /**
@@ -87,7 +88,7 @@ package object syntax {
     def withAsync(
         timeWindow: FiniteDuration = 1.millis,
         maxBufferSize: Option[Int] = None
-    )(implicit timer: Timer[F], F: Concurrent[F], contextShift: ContextShift[F]): Resource[F, Logger[F]] =
+    )(implicit F: Async[F]): Resource[F, Logger[F]] =
       resource.flatMap(AsyncLogger.withAsync(_, timeWindow, maxBufferSize))
 
     /**

--- a/core/src/test/scala/io/odin/OdinSpec.scala
+++ b/core/src/test/scala/io/odin/OdinSpec.scala
@@ -1,7 +1,6 @@
 package io.odin
 
 import java.time.LocalDateTime
-
 import cats.effect.Clock
 import cats.{Applicative, Eval}
 import io.odin.formatter.Formatter
@@ -12,7 +11,7 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.scalacheck.{Checkers, ScalaCheckDrivenPropertyChecks}
 import org.typelevel.discipline.Laws
 
-import scala.concurrent.duration.TimeUnit
+import scala.concurrent.duration._
 
 trait OdinSpec extends AnyFlatSpec with Matchers with Checkers with ScalaCheckDrivenPropertyChecks with EqInstances {
   def checkAll(name: String, ruleSet: Laws#RuleSet): Unit = {
@@ -25,8 +24,9 @@ trait OdinSpec extends AnyFlatSpec with Matchers with Checkers with ScalaCheckDr
   def zeroClock[F[_]: Applicative]: Clock[F] = fixedClock(0)
 
   def fixedClock[F[_]](time: Long)(implicit F: Applicative[F]): Clock[F] = new Clock[F] {
-    def realTime(unit: TimeUnit): F[Long] = F.pure(time)
-    def monotonic(unit: TimeUnit): F[Long] = F.pure(time)
+    def applicative: Applicative[F] = F
+    def monotonic: F[FiniteDuration] = F.pure(time.millis)
+    def realTime: F[FiniteDuration] = F.pure(time.millis)
   }
 
   val lineSeparator: String = System.lineSeparator()

--- a/core/src/test/scala/io/odin/config/ConfigSpec.scala
+++ b/core/src/test/scala/io/odin/config/ConfigSpec.scala
@@ -1,13 +1,15 @@
 package io.odin.config
 
 import cats.data.WriterT
-import cats.effect.{IO, Timer}
+import cats.effect.IO
+import cats.effect.unsafe.IORuntime
 import cats.syntax.all._
 import io.odin.loggers.DefaultLogger
 import io.odin.{Level, Logger, LoggerMessage, OdinSpec}
 
 class ConfigSpec extends OdinSpec {
-  implicit val timer: Timer[IO] = IO.timer(scala.concurrent.ExecutionContext.global)
+
+  private implicit val ioRuntime: IORuntime = IORuntime.global
 
   type F[A] = WriterT[IO, List[(String, LoggerMessage)], A]
 

--- a/core/src/test/scala/io/odin/config/ConfigSpec.scala
+++ b/core/src/test/scala/io/odin/config/ConfigSpec.scala
@@ -9,7 +9,7 @@ import io.odin.{Level, Logger, LoggerMessage, OdinSpec}
 
 class ConfigSpec extends OdinSpec {
 
-  private implicit val ioRuntime: IORuntime = IORuntime.global
+  implicit private val ioRuntime: IORuntime = IORuntime.global
 
   type F[A] = WriterT[IO, List[(String, LoggerMessage)], A]
 

--- a/core/src/test/scala/io/odin/loggers/AsyncLoggerSpec.scala
+++ b/core/src/test/scala/io/odin/loggers/AsyncLoggerSpec.scala
@@ -1,16 +1,17 @@
 package io.odin.loggers
 
 import cats.effect.std.Queue
-import cats.effect.testkit.{TestContext, TestInstances}
-import cats.effect.{IO, Outcome, Ref, Resource}
+import cats.effect.unsafe.IORuntime
+import cats.effect.{IO, Ref, Resource}
 import cats.syntax.all._
 import io.odin.syntax._
 import io.odin.{Level, Logger, LoggerMessage, OdinSpec}
 
 import scala.concurrent.duration._
 
-class AsyncLoggerSpec extends OdinSpec with TestInstances {
-  private implicit val ticker: Ticker = Ticker(TestContext())
+class AsyncLoggerSpec extends OdinSpec {
+
+  private implicit val ioRuntime: IORuntime = IORuntime.global
 
   case class RefLogger(ref: Ref[IO, List[LoggerMessage]], override val minLevel: Level = Level.Trace)
       extends DefaultLogger[IO](minLevel) {
@@ -25,30 +26,28 @@ class AsyncLoggerSpec extends OdinSpec with TestInstances {
 
   it should "push logs down the chain" in {
     forAll { msgs: List[LoggerMessage] =>
-      val io =
-        for {
-          ref <- Resource.eval(Ref.of[IO, List[LoggerMessage]](List.empty))
-          logger <- RefLogger(ref).withMinimalLevel(Level.Trace).withAsync()
-          _ <- Resource.eval(msgs.traverse(logger.log))
-          _ = ticker.ctx.tick(10.millis)
-          reported <- Resource.eval(ref.get)
-        } yield reported
-
-      unsafeRun(io.use(IO(_))) shouldBe Outcome.succeeded(Some(msgs))
+      (for {
+        ref <- Resource.eval(Ref.of[IO, List[LoggerMessage]](List.empty))
+        logger <- RefLogger(ref).withMinimalLevel(Level.Trace).withAsync()
+        _ <- Resource.eval(msgs.traverse(logger.log))
+        _ <- Resource.eval(IO.sleep(10.millis))
+        reported <- Resource.eval(ref.get)
+      } yield {
+        reported shouldBe msgs
+      }).use(IO(_)).unsafeRunSync()
     }
   }
 
   it should "push logs to the queue" in {
     forAll { msgs: List[LoggerMessage] =>
-      val io =
-        for {
-          queue <- Queue.unbounded[IO, LoggerMessage]
-          logger = AsyncLogger(queue, 1.millis, Logger.noop[IO]).withMinimalLevel(Level.Trace)
-          _ <- msgs.traverse(logger.log)
-          reported <- List.fill(msgs.length)(queue.take).sequence
-        } yield reported
-
-      unsafeRun(io) shouldBe Outcome.succeeded(Some(msgs))
+      (for {
+        queue <- Queue.unbounded[IO, LoggerMessage]
+        logger = AsyncLogger(queue, 1.millis, Logger.noop[IO]).withMinimalLevel(Level.Trace)
+        _ <- msgs.traverse(logger.log)
+        reported <- List.fill(msgs.length)(queue.take).sequence
+      } yield {
+        reported shouldBe msgs
+      }).unsafeRunSync()
     }
   }
 
@@ -59,15 +58,14 @@ class AsyncLoggerSpec extends OdinSpec with TestInstances {
       def withMinimalLevel(level: Level): Logger[IO] = this
     }
     forAll { msgs: List[LoggerMessage] =>
-      val io =
-        for {
-          queue <- Queue.unbounded[IO, LoggerMessage]
-          logger = AsyncLogger(queue, 1.millis, errorLogger)
-          _ <- logger.log(msgs)
-          result <- logger.drain
-        } yield result
-
-      unsafeRun(io) shouldBe Outcome.succeeded(Some(()))
+      (for {
+        queue <- Queue.unbounded[IO, LoggerMessage]
+        logger = AsyncLogger(queue, 1.millis, errorLogger)
+        _ <- logger.log(msgs)
+        result <- logger.drain
+      } yield {
+        result shouldBe (())
+      }).unsafeRunSync()
     }
   }
 }

--- a/core/src/test/scala/io/odin/loggers/AsyncLoggerSpec.scala
+++ b/core/src/test/scala/io/odin/loggers/AsyncLoggerSpec.scala
@@ -1,72 +1,73 @@
 package io.odin.loggers
 
-import cats.effect.Resource
-import cats.effect.concurrent.Ref
+import cats.effect.std.Queue
+import cats.effect.testkit.{TestContext, TestInstances}
+import cats.effect.{IO, Outcome, Ref, Resource}
 import cats.syntax.all._
-import io.odin.{Level, Logger, LoggerMessage, OdinSpec}
-import monix.catnap.ConcurrentQueue
-import monix.eval.Task
-import monix.execution.schedulers.TestScheduler
 import io.odin.syntax._
+import io.odin.{Level, Logger, LoggerMessage, OdinSpec}
 
 import scala.concurrent.duration._
 
-class AsyncLoggerSpec extends OdinSpec {
-  implicit private val scheduler: TestScheduler = TestScheduler()
+class AsyncLoggerSpec extends OdinSpec with TestInstances {
+  private implicit val ticker: Ticker = Ticker(TestContext())
 
-  case class RefLogger(ref: Ref[Task, List[LoggerMessage]], override val minLevel: Level = Level.Trace)
-      extends DefaultLogger[Task](minLevel) {
-    def submit(msg: LoggerMessage): Task[Unit] = Task.raiseError(new IllegalStateException("Async should always batch"))
+  case class RefLogger(ref: Ref[IO, List[LoggerMessage]], override val minLevel: Level = Level.Trace)
+      extends DefaultLogger[IO](minLevel) {
+    def submit(msg: LoggerMessage): IO[Unit] = IO.raiseError(new IllegalStateException("Async should always batch"))
 
-    override def submit(msgs: List[LoggerMessage]): Task[Unit] = {
+    override def submit(msgs: List[LoggerMessage]): IO[Unit] = {
       ref.update(_ ::: msgs)
     }
 
-    def withMinimalLevel(level: Level): Logger[Task] = copy(minLevel = level)
+    def withMinimalLevel(level: Level): Logger[IO] = copy(minLevel = level)
   }
 
   it should "push logs down the chain" in {
     forAll { msgs: List[LoggerMessage] =>
-      (for {
-        ref <- Resource.liftF(Ref.of[Task, List[LoggerMessage]](List.empty))
-        logger <- RefLogger(ref).withMinimalLevel(Level.Trace).withAsync()
-        _ <- Resource.liftF(msgs.traverse(logger.log))
-        _ = scheduler.tick(10.millis)
-        reported <- Resource.liftF(ref.get)
-      } yield {
-        reported shouldBe msgs
-      }).use(Task(_)).runSyncUnsafe()
+      val io =
+        for {
+          ref <- Resource.eval(Ref.of[IO, List[LoggerMessage]](List.empty))
+          logger <- RefLogger(ref).withMinimalLevel(Level.Trace).withAsync()
+          _ <- Resource.eval(msgs.traverse(logger.log))
+          _ = ticker.ctx.tick(10.millis)
+          reported <- Resource.eval(ref.get)
+        } yield reported
+
+      unsafeRun(io.use(IO(_))) shouldBe Outcome.succeeded(Some(msgs))
     }
   }
 
   it should "push logs to the queue" in {
     forAll { msgs: List[LoggerMessage] =>
-      (for {
-        queue <- ConcurrentQueue.unbounded[Task, LoggerMessage]()
-        logger = AsyncLogger(queue, 1.millis, Logger.noop[Task]).withMinimalLevel(Level.Trace)
-        _ <- msgs.traverse(logger.log)
-        reported <- queue.drain(0, Int.MaxValue)
-      } yield {
-        reported shouldBe msgs
-      }).runSyncUnsafe()
+      val io =
+        for {
+          queue <- Queue.unbounded[IO, LoggerMessage]
+          logger = AsyncLogger(queue, 1.millis, Logger.noop[IO]).withMinimalLevel(Level.Trace)
+          _ <- msgs.traverse(logger.log)
+          reported <- List.fill(msgs.length)(queue.take).sequence
+        } yield reported
+
+      unsafeRun(io) shouldBe Outcome.succeeded(Some(msgs))
     }
   }
 
   it should "ignore errors in underlying logger" in {
-    val errorLogger = new DefaultLogger[Task](Level.Trace) {
-      def submit(msg: LoggerMessage): Task[Unit] = Task.raiseError(new Error)
+    val errorLogger = new DefaultLogger[IO](Level.Trace) {
+      def submit(msg: LoggerMessage): IO[Unit] = IO.raiseError(new Error)
 
-      def withMinimalLevel(level: Level): Logger[Task] = this
+      def withMinimalLevel(level: Level): Logger[IO] = this
     }
     forAll { msgs: List[LoggerMessage] =>
-      (for {
-        queue <- ConcurrentQueue.unbounded[Task, LoggerMessage]()
-        logger = AsyncLogger(queue, 1.millis, errorLogger)
-        _ <- logger.log(msgs)
-        result <- logger.drain
-      } yield {
-        result shouldBe (())
-      }).runSyncUnsafe()
+      val io =
+        for {
+          queue <- Queue.unbounded[IO, LoggerMessage]
+          logger = AsyncLogger(queue, 1.millis, errorLogger)
+          _ <- logger.log(msgs)
+          result <- logger.drain
+        } yield result
+
+      unsafeRun(io) shouldBe Outcome.succeeded(Some(()))
     }
   }
 }

--- a/core/src/test/scala/io/odin/loggers/AsyncLoggerSpec.scala
+++ b/core/src/test/scala/io/odin/loggers/AsyncLoggerSpec.scala
@@ -11,7 +11,7 @@ import scala.concurrent.duration._
 
 class AsyncLoggerSpec extends OdinSpec {
 
-  private implicit val ioRuntime: IORuntime = IORuntime.global
+  implicit private val ioRuntime: IORuntime = IORuntime.global
 
   case class RefLogger(ref: Ref[IO, List[LoggerMessage]], override val minLevel: Level = Level.Trace)
       extends DefaultLogger[IO](minLevel) {

--- a/core/src/test/scala/io/odin/loggers/ConsoleLoggerSpec.scala
+++ b/core/src/test/scala/io/odin/loggers/ConsoleLoggerSpec.scala
@@ -1,15 +1,17 @@
 package io.odin.loggers
 
-import java.io.{ByteArrayOutputStream, PrintStream}
-
-import cats.effect.{IO, Timer}
+import cats.effect.IO
+import cats.effect.unsafe.IORuntime
 import cats.syntax.all._
 import io.odin.Level._
 import io.odin.formatter.Formatter
 import io.odin.{Level, LoggerMessage, OdinSpec}
 
+import java.io.{ByteArrayOutputStream, PrintStream}
+
 class ConsoleLoggerSpec extends OdinSpec {
-  implicit val timer: Timer[IO] = IO.timer(scala.concurrent.ExecutionContext.global)
+
+  private implicit val ioRuntime: IORuntime = IORuntime.global
 
   it should "route all messages with level <= INFO to stdout" in {
     forAll { (loggerMessage: LoggerMessage, formatter: Formatter) =>

--- a/core/src/test/scala/io/odin/loggers/ConsoleLoggerSpec.scala
+++ b/core/src/test/scala/io/odin/loggers/ConsoleLoggerSpec.scala
@@ -1,5 +1,7 @@
 package io.odin.loggers
 
+import java.io.{ByteArrayOutputStream, PrintStream}
+
 import cats.effect.IO
 import cats.effect.unsafe.IORuntime
 import cats.syntax.all._
@@ -7,11 +9,9 @@ import io.odin.Level._
 import io.odin.formatter.Formatter
 import io.odin.{Level, LoggerMessage, OdinSpec}
 
-import java.io.{ByteArrayOutputStream, PrintStream}
-
 class ConsoleLoggerSpec extends OdinSpec {
 
-  private implicit val ioRuntime: IORuntime = IORuntime.global
+  implicit private val ioRuntime: IORuntime = IORuntime.global
 
   it should "route all messages with level <= INFO to stdout" in {
     forAll { (loggerMessage: LoggerMessage, formatter: Formatter) =>

--- a/core/src/test/scala/io/odin/loggers/DefaultLoggerSpec.scala
+++ b/core/src/test/scala/io/odin/loggers/DefaultLoggerSpec.scala
@@ -6,11 +6,14 @@ import cats.effect.Clock
 import cats.syntax.all._
 import io.odin.{Level, Logger, LoggerMessage, OdinSpec}
 
+import scala.concurrent.duration.FiniteDuration
+
 class DefaultLoggerSpec extends OdinSpec {
   type F[A] = Writer[List[LoggerMessage], A]
 
   it should "correctly construct LoggerMessage" in {
-    forAll { (msg: String, ctx: Map[String, String], throwable: Throwable, timestamp: Long) =>
+    forAll { (msg: String, ctx: Map[String, String], throwable: Throwable, ts: FiniteDuration) =>
+      val timestamp = ts.toMillis
       implicit val clk: Clock[Id] = fixedClock(timestamp)
       val log = logger().withMinimalLevel(Level.Trace)
       check(log.trace(msg))(Level.Trace, msg, timestamp)

--- a/core/src/test/scala/io/odin/loggers/FileLoggerSpec.scala
+++ b/core/src/test/scala/io/odin/loggers/FileLoggerSpec.scala
@@ -13,7 +13,7 @@ import scala.concurrent.duration._
 
 class FileLoggerSpec extends OdinSpec {
 
-  private implicit val ioRuntime: IORuntime = IORuntime.global
+  implicit private val ioRuntime: IORuntime = IORuntime.global
 
   private val fileResource = Resource.make[IO, Path] {
     IO.delay(Files.createTempFile(UUID.randomUUID().toString, ""))

--- a/core/src/test/scala/io/odin/loggers/FileLoggerSpec.scala
+++ b/core/src/test/scala/io/odin/loggers/FileLoggerSpec.scala
@@ -2,68 +2,73 @@ package io.odin.loggers
 
 import java.nio.file.{Files, Path, Paths}
 import java.util.UUID
-
-import cats.effect.Resource
+import cats.effect.{IO, Outcome, Resource}
+import cats.effect.testkit.{TestContext, TestInstances}
 import io.odin._
 import io.odin.formatter.Formatter
 import io.odin.{LoggerMessage, OdinSpec}
+
 import scala.concurrent.duration._
-import monix.eval.Task
-import monix.execution.schedulers.TestScheduler
 
-class FileLoggerSpec extends OdinSpec {
-  implicit private val scheduler: TestScheduler = TestScheduler()
+class FileLoggerSpec extends OdinSpec with TestInstances {
 
-  private val fileResource = Resource.make[Task, Path] {
-    Task.delay(Files.createTempFile(UUID.randomUUID().toString, ""))
+  private val fileResource = Resource.make[IO, Path] {
+    IO.delay(Files.createTempFile(UUID.randomUUID().toString, ""))
   } { file =>
-    Task.delay(Files.delete(file))
+    IO.delay(Files.delete(file))
   }
 
   it should "write formatted message into file" in {
     forAll { (loggerMessage: LoggerMessage, formatter: Formatter) =>
+      import cats.effect.unsafe.implicits.global
+
       (for {
         path <- fileResource
         fileName = path.toString
-        logger <- FileLogger[Task](fileName, formatter, Level.Trace)
-        _ <- Resource.liftF(logger.log(loggerMessage))
+        logger <- FileLogger[IO](fileName, formatter, Level.Trace)
+        _ <- Resource.eval(logger.log(loggerMessage))
       } yield {
         new String(Files.readAllBytes(Paths.get(fileName))) shouldBe formatter.format(loggerMessage) + lineSeparator
-      }).use(Task(_))
-        .runSyncUnsafe()
+      }).use(IO(_))
+        .unsafeRunSync()
     }
   }
 
   it should "write formatted messages into file" in {
     forAll { (loggerMessage: List[LoggerMessage], formatter: Formatter) =>
+      import cats.effect.unsafe.implicits.global
+
       (for {
         path <- fileResource
         fileName = path.toString
-        logger <- FileLogger[Task](fileName, formatter, Level.Trace)
-        _ <- Resource.liftF(logger.log(loggerMessage))
+        logger <- FileLogger[IO](fileName, formatter, Level.Trace)
+        _ <- Resource.eval(logger.log(loggerMessage))
       } yield {
         new String(Files.readAllBytes(Paths.get(fileName))) shouldBe loggerMessage
           .map(formatter.format)
           .mkString(lineSeparator) + (if (loggerMessage.isEmpty) "" else lineSeparator)
-      }).use(Task(_))
-        .runSyncUnsafe()
+      }).use(IO(_))
+        .unsafeRunSync()
     }
   }
 
   it should "write in async mode" in {
+    implicit val ticker: Ticker = Ticker(TestContext())
+
     forAll { (loggerMessage: List[LoggerMessage], formatter: Formatter) =>
-      (for {
+      val expected = loggerMessage
+        .map(formatter.format)
+        .mkString(lineSeparator) + (if (loggerMessage.isEmpty) "" else lineSeparator)
+
+      val io = for {
         path <- fileResource
         fileName = path.toString
-        logger <- asyncFileLogger[Task](fileName, formatter)
-        _ <- Resource.liftF(logger.withMinimalLevel(Level.Trace).log(loggerMessage))
-        _ <- Resource.liftF(Task(scheduler.tick(2.seconds)))
-      } yield {
-        new String(Files.readAllBytes(Paths.get(fileName))) shouldBe loggerMessage
-          .map(formatter.format)
-          .mkString(lineSeparator) + (if (loggerMessage.isEmpty) "" else lineSeparator)
-      }).use(Task(_))
-        .runSyncUnsafe()
+        logger <- asyncFileLogger[IO](fileName, formatter)
+        _ <- Resource.eval(logger.withMinimalLevel(Level.Trace).log(loggerMessage))
+        _ <- Resource.eval(IO(ticker.ctx.tick(2.seconds)))
+      } yield new String(Files.readAllBytes(Paths.get(fileName)))
+
+      unsafeRun(io.use(IO(_))) shouldBe Outcome.succeeded(Some(expected))
     }
   }
 }

--- a/core/src/test/scala/io/odin/loggers/FilterLoggerSpec.scala
+++ b/core/src/test/scala/io/odin/loggers/FilterLoggerSpec.scala
@@ -19,7 +19,10 @@ class FilterLoggerSpec extends OdinSpec {
 
   checkAll(
     "FilterLogger",
-    LoggerTests[F](new WriterTLogger[IO].filter(_.exception.isDefined), _.written.evalOn(singleThreadCtx).unsafeRunSync()).all
+    LoggerTests[F](
+      new WriterTLogger[IO].filter(_.exception.isDefined),
+      _.written.evalOn(singleThreadCtx).unsafeRunSync()
+    ).all
   )
 
   it should "logger.filter(p).log(msg) <-> F.whenA(p)(log(msg))" in {

--- a/core/src/test/scala/io/odin/loggers/FilterLoggerSpec.scala
+++ b/core/src/test/scala/io/odin/loggers/FilterLoggerSpec.scala
@@ -1,18 +1,25 @@
 package io.odin.loggers
 
+import java.util.concurrent.Executors
+
 import cats.data.WriterT
+import cats.effect.unsafe.IORuntime
 import cats.effect.{Clock, IO}
 import cats.syntax.all._
 import io.odin._
 import io.odin.syntax._
 
+import scala.concurrent.ExecutionContext
+
 class FilterLoggerSpec extends OdinSpec {
   type F[A] = WriterT[IO, List[LoggerMessage], A]
   implicit val clock: Clock[IO] = zeroClock
+  implicit val ioRuntime: IORuntime = IORuntime.global
+  private val singleThreadCtx: ExecutionContext = ExecutionContext.fromExecutor(Executors.newSingleThreadExecutor())
 
   checkAll(
     "FilterLogger",
-    LoggerTests[F](new WriterTLogger[IO].filter(_.exception.isDefined), _.written.unsafeRunSync()).all
+    LoggerTests[F](new WriterTLogger[IO].filter(_.exception.isDefined), _.written.evalOn(singleThreadCtx).unsafeRunSync()).all
   )
 
   it should "logger.filter(p).log(msg) <-> F.whenA(p)(log(msg))" in {

--- a/core/src/test/scala/io/odin/loggers/LoggerMonoidSpec.scala
+++ b/core/src/test/scala/io/odin/loggers/LoggerMonoidSpec.scala
@@ -1,16 +1,18 @@
 package io.odin.loggers
 
-import java.util.UUID
-
 import cats.data.WriterT
+import cats.effect.unsafe.IORuntime
 import cats.effect.{Clock, IO}
 import cats.kernel.laws.discipline.MonoidTests
 import cats.syntax.all._
 import io.odin.{Level, Logger, LoggerMessage, OdinSpec}
 import org.scalacheck.{Arbitrary, Gen}
 
+import java.util.UUID
+
 class LoggerMonoidSpec extends OdinSpec {
   type F[A] = WriterT[IO, List[(UUID, LoggerMessage)], A]
+  implicit val ioRuntime: IORuntime = IORuntime.global
 
   checkAll("Logger", MonoidTests[Logger[F]].monoid)
 

--- a/core/src/test/scala/io/odin/loggers/LoggerNatTransformSpec.scala
+++ b/core/src/test/scala/io/odin/loggers/LoggerNatTransformSpec.scala
@@ -3,7 +3,7 @@ package io.odin.loggers
 import cats.data.{Writer, WriterT}
 import cats.effect.unsafe.IORuntime
 import cats.effect.{Clock, IO}
-import cats.{Id, ~>}
+import cats.{~>, Id}
 import io.odin.{Level, Logger, LoggerMessage, OdinSpec}
 
 import scala.concurrent.duration.FiniteDuration
@@ -12,7 +12,7 @@ class LoggerNatTransformSpec extends OdinSpec {
   type F[A] = Writer[List[LoggerMessage], A]
   type FF[A] = WriterT[IO, List[LoggerMessage], A]
 
-  private implicit val ioRuntime: IORuntime = IORuntime.global
+  implicit private val ioRuntime: IORuntime = IORuntime.global
 
   it should "transform each method" in {
     forAll { (msg: String, ctx: Map[String, String], throwable: Throwable, ts: FiniteDuration) =>

--- a/core/src/test/scala/io/odin/loggers/RollingFileLoggerSpec.scala
+++ b/core/src/test/scala/io/odin/loggers/RollingFileLoggerSpec.scala
@@ -4,49 +4,49 @@ import java.nio.file.{Files, Path}
 import java.time.format.DateTimeFormatter
 import java.time.{Instant, LocalDateTime}
 import java.util.{TimeZone, UUID}
-import java.util.concurrent.TimeUnit
 
-import cats.effect.{Resource, Timer}
+import cats.effect.testkit.TestInstances
+import cats.effect.unsafe.IORuntime
+import cats.effect.{IO, Resource}
 import io.odin.config._
 import io.odin.formatter.Formatter
 import io.odin.util.ListDirectory
-import io.odin.{asyncRollingFileLogger, Level, LoggerMessage, OdinSpec}
-import monix.eval.Task
-import monix.execution.schedulers.TestScheduler
+import io.odin.{Level, LoggerMessage, OdinSpec}
 
 import scala.concurrent.duration._
 
-class RollingFileLoggerSpec extends OdinSpec {
+class RollingFileLoggerSpec extends OdinSpec with TestInstances {
 
-  private val fileResource = Resource.make[Task, Path] {
-    Task.delay(Files.createTempDirectory(UUID.randomUUID().toString))
+  private implicit val ioRuntime: IORuntime = IORuntime.global
+
+  private val fileResource = Resource.make[IO, Path] {
+    IO.delay(Files.createTempDirectory(UUID.randomUUID().toString))
   } { file =>
-    Task.delay {
+    IO.delay {
       ListDirectory(file).filter(_.isFile).foreach(_.delete())
       Files.delete(file)
-    }
+    }.attempt.void
   }
 
   {
-    implicit val scheduler: TestScheduler = TestScheduler()
     it should "write formatted message into file" in {
       forAll { (loggerMessage: LoggerMessage, formatter: Formatter) =>
         (for {
           path <- fileResource
           filePrefix = path.toString
-          logger <- RollingFileLogger[Task](
+          logger <- RollingFileLogger[IO](
             file"$filePrefix/log-$year-$month-$day-$hour-$minute-$second.log",
             maxFileSizeInBytes = None,
             rolloverInterval = None,
             formatter = formatter,
             minLevel = Level.Trace
           )
-          _ <- Resource.liftF(logger.log(loggerMessage))
+          _ <- Resource.eval(logger.log(loggerMessage))
         } yield {
           val logFile = ListDirectory(path).filter(_.isFile).head.toPath
           new String(Files.readAllBytes(logFile)) shouldBe formatter.format(loggerMessage) + lineSeparator
-        }).use(Task(_))
-          .runSyncUnsafe()
+        }).use(IO(_))
+          .unsafeRunSync()
       }
     }
 
@@ -55,54 +55,59 @@ class RollingFileLoggerSpec extends OdinSpec {
         (for {
           path <- fileResource
           filePrefix = path.toString
-          logger <- RollingFileLogger[Task](
+          logger <- RollingFileLogger[IO](
             file"$filePrefix/log-$year-$month-$day-$hour-$minute-$second.log",
             maxFileSizeInBytes = None,
             rolloverInterval = None,
             formatter = formatter,
             minLevel = Level.Trace
           )
-          _ <- Resource.liftF(logger.log(loggerMessage))
+          _ <- Resource.eval(logger.log(loggerMessage))
         } yield {
           val logFile = ListDirectory(path).filter(_.isFile).head.toPath
           new String(Files.readAllBytes(logFile)) shouldBe loggerMessage
             .map(formatter.format)
             .mkString(lineSeparator) + (if (loggerMessage.isEmpty) "" else lineSeparator)
-        }).use(Task(_))
-          .runSyncUnsafe()
+        }).use(IO(_))
+          .unsafeRunSync()
       }
     }
 
-    it should "write in async mode" in {
+    /*it should "write in async mode" in {
       forAll { (loggerMessage: List[LoggerMessage], formatter: Formatter) =>
-        (for {
+        //implicit val ticker: Ticker = Ticker(TestContext())
+
+        val io = for {
           path <- fileResource
           filePrefix = path.toString
-          logger <- asyncRollingFileLogger[Task](
+          logger <- asyncRollingFileLogger[IO](
             file"$filePrefix/log-$year-$month-$day-$hour-$minute-$second.log",
             rolloverInterval = None,
             maxFileSizeInBytes = None,
             formatter = formatter,
             minLevel = Level.Trace
           )
-          _ <- Resource.liftF(logger.withMinimalLevel(Level.Trace).log(loggerMessage))
-          _ <- Resource.liftF(Task(scheduler.tick(2.seconds)))
+          _ <- Resource.eval(logger.withMinimalLevel(Level.Trace).log(loggerMessage))
+          _ <- Resource.eval(IO.sleep(1200.millis)) // ticker.ctx.tick(2.seconds)
         } yield {
           val logFile = ListDirectory(path).filter(_.isFile).head.toPath
-          new String(Files.readAllBytes(logFile)) shouldBe loggerMessage
-            .map(formatter.format)
-            .mkString(lineSeparator) + (if (loggerMessage.isEmpty) "" else lineSeparator)
-        }).use(Task(_))
-          .runSyncUnsafe()
+          new String(Files.readAllBytes(logFile))
+        }
+
+        val expected = loggerMessage
+          .map(formatter.format)
+          .mkString(lineSeparator) + (if (loggerMessage.isEmpty) "" else lineSeparator)
+
+        io.use(IO(_)).unsafeRunSync() shouldBe expected
       }
-    }
+    }*/
 
     it should "log file name should match the pattern" in {
       (for {
         path <- fileResource
-        time <- Resource.liftF(implicitly[Timer[Task]].clock.realTime(TimeUnit.MILLISECONDS))
+        time <- Resource.eval(IO.realTime)
         filePrefix = path.toString
-        _ <- RollingFileLogger[Task](
+        _ <- RollingFileLogger[IO](
           file"$filePrefix/log-$year-$month-$day-$hour-$minute-$second.log",
           maxFileSizeInBytes = None,
           rolloverInterval = None,
@@ -111,39 +116,36 @@ class RollingFileLoggerSpec extends OdinSpec {
         )
       } yield {
         val logFile = ListDirectory(path).filter(_.isFile).head.toPath
-        val localDt = LocalDateTime.ofInstant(Instant.ofEpochMilli(time), TimeZone.getDefault.toZoneId)
+        val localDt = LocalDateTime.ofInstant(Instant.ofEpochMilli(time.toMillis), TimeZone.getDefault.toZoneId)
         val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd-HH-mm-ss")
         val formatted = formatter.format(localDt)
         logFile.toString shouldBe s"$filePrefix/log-$formatted.log"
-      }).use(Task(_))
-        .runSyncUnsafe()
+      }).use(IO(_)).unsafeRunSync()
     }
   }
 
   {
-    //@TODO TestScheduler is somewhat broken for this case
-    import monix.execution.Scheduler.Implicits.global
     it should "write to the next file once interval is over" in {
       forAll { (lm1: LoggerMessage, lm2: LoggerMessage, formatter: Formatter) =>
         (for {
           path <- fileResource
           filePrefix = path.toString
-          logger <- RollingFileLogger[Task](
+          logger <- RollingFileLogger[IO](
             file"$filePrefix/log-$year-$month-$day-$hour-$minute-$second.log",
             maxFileSizeInBytes = None,
             rolloverInterval = Some(1.second),
             formatter = formatter,
             minLevel = Level.Trace
           )
-          _ <- Resource.liftF(logger.log(lm1))
-          _ <- Resource.liftF(Task.sleep(1200.millis))
-          _ <- Resource.liftF(logger.log(lm2))
+          _ <- Resource.eval(logger.log(lm1))
+          _ <- Resource.eval(IO.sleep(1200.millis))
+          _ <- Resource.eval(logger.log(lm2))
         } yield {
           val log1 :: log2 :: Nil = ListDirectory(path).filter(_.isFile).sortBy(_.getName)
           new String(Files.readAllBytes(log1.toPath)) shouldBe formatter.format(lm1) + lineSeparator
           new String(Files.readAllBytes(log2.toPath)) shouldBe formatter.format(lm2) + lineSeparator
-        }).use(Task(_))
-          .runSyncUnsafe()
+        }).use(IO(_))
+          .unsafeRunSync()
       }
     }
 
@@ -152,23 +154,23 @@ class RollingFileLoggerSpec extends OdinSpec {
         (for {
           path <- fileResource
           filePrefix = path.toString
-          logger <- RollingFileLogger[Task](
+          logger <- RollingFileLogger[IO](
             file"$filePrefix/log-$year-$month-$day-$hour-$minute-$second.log",
             maxFileSizeInBytes = Some(1),
             rolloverInterval = None,
             formatter = formatter,
             minLevel = Level.Trace
           )
-          _ <- Resource.liftF(Task.sleep(1.second))
-          _ <- Resource.liftF(logger.log(lm1))
-          _ <- Resource.liftF(Task.sleep(1.second))
-          _ <- Resource.liftF(logger.log(lm2))
+          _ <- Resource.eval(IO.sleep(1.second))
+          _ <- Resource.eval(logger.log(lm1))
+          _ <- Resource.eval(IO.sleep(1.second))
+          _ <- Resource.eval(logger.log(lm2))
         } yield {
           val log1 :: log2 :: Nil = ListDirectory(path).filter(_.isFile).sortBy(_.getName)
           new String(Files.readAllBytes(log1.toPath)) shouldBe formatter.format(lm1) + lineSeparator
           new String(Files.readAllBytes(log2.toPath)) shouldBe formatter.format(lm2) + lineSeparator
-        }).use(Task(_))
-          .runSyncUnsafe()
+        }).use(IO(_))
+          .unsafeRunSync()
       }
     }
   }

--- a/core/src/test/scala/io/odin/loggers/RollingFileLoggerSpec.scala
+++ b/core/src/test/scala/io/odin/loggers/RollingFileLoggerSpec.scala
@@ -10,21 +10,23 @@ import cats.effect.{IO, Resource}
 import io.odin.config._
 import io.odin.formatter.Formatter
 import io.odin.util.ListDirectory
-import io.odin.{Level, LoggerMessage, OdinSpec, asyncRollingFileLogger}
+import io.odin.{asyncRollingFileLogger, Level, LoggerMessage, OdinSpec}
 
 import scala.concurrent.duration._
 
 class RollingFileLoggerSpec extends OdinSpec {
 
-  private implicit val ioRuntime: IORuntime = IORuntime.global
+  implicit private val ioRuntime: IORuntime = IORuntime.global
 
   private val fileResource = Resource.make[IO, Path] {
     IO.delay(Files.createTempDirectory(UUID.randomUUID().toString))
   } { file =>
     IO.delay {
-      ListDirectory(file).filter(_.isFile).foreach(_.delete())
-      Files.delete(file)
-    }.attempt.void
+        ListDirectory(file).filter(_.isFile).foreach(_.delete())
+        Files.delete(file)
+      }
+      .attempt
+      .void
   }
 
   {

--- a/core/src/test/scala/io/odin/loggers/RollingFileLoggerSpec.scala
+++ b/core/src/test/scala/io/odin/loggers/RollingFileLoggerSpec.scala
@@ -84,11 +84,10 @@ class RollingFileLoggerSpec extends OdinSpec {
             rolloverInterval = None,
             maxFileSizeInBytes = None,
             formatter = formatter,
-            minLevel = Level.Trace,
-            timeWindow = 10.millis
+            minLevel = Level.Trace
           )
           _ <- Resource.eval(logger.withMinimalLevel(Level.Trace).log(loggerMessage))
-          _ <- Resource.eval(IO.sleep(30.millis))
+          _ <- Resource.eval(IO.sleep(2.seconds))
         } yield {
           val logFile = ListDirectory(path).filter(_.isFile).head.toPath
           new String(Files.readAllBytes(logFile)) shouldBe loggerMessage

--- a/examples/src/main/scala/io/odin/examples/AsyncHelloWorld.scala
+++ b/examples/src/main/scala/io/odin/examples/AsyncHelloWorld.scala
@@ -1,6 +1,6 @@
 package io.odin.examples
 
-import cats.effect.{ExitCode, IO, IOApp, Resource}
+import cats.effect.{IO, IOApp, Resource}
 import io.odin._
 import io.odin.syntax._
 
@@ -9,11 +9,11 @@ import io.odin.syntax._
   *
   * To safely allocate, release and drain this queue, async logger is wrapped in `Resource`
   */
-object AsyncHelloWorld extends IOApp {
+object AsyncHelloWorld extends IOApp.Simple {
   val loggerResource: Resource[IO, Logger[IO]] = consoleLogger[IO]().withAsync()
 
-  def run(args: List[String]): IO[ExitCode] =
+  def run: IO[Unit] =
     loggerResource
       .use(logger => logger.info("Hello world"))
-      .as(ExitCode.Success)
+
 }

--- a/examples/src/main/scala/io/odin/examples/ClassBasedRouting.scala
+++ b/examples/src/main/scala/io/odin/examples/ClassBasedRouting.scala
@@ -1,6 +1,6 @@
 package io.odin.examples
 
-import cats.effect.{ExitCode, IO, IOApp}
+import cats.effect.{IO, IOApp}
 import io.odin._
 import io.odin.config._
 
@@ -8,15 +8,15 @@ import io.odin.config._
   * Only one logger will print the message, as one of them will be routed to the logger with minimal level WARN,
   * but both print only info messages
   */
-object ClassBasedRouting extends IOApp {
+object ClassBasedRouting extends IOApp.Simple {
   val logger: Logger[IO] =
     classRouting[IO](
       classOf[Foo[_]] -> consoleLogger[IO]().withMinimalLevel(Level.Warn),
       classOf[Bar[_]] -> consoleLogger[IO]().withMinimalLevel(Level.Info)
     ).withNoopFallback
 
-  def run(args: List[String]): IO[ExitCode] = {
-    (Foo(logger).log *> Bar(logger).log).as(ExitCode.Success)
+  def run: IO[Unit] = {
+    (Foo(logger).log *> Bar(logger).log)
   }
 }
 

--- a/examples/src/main/scala/io/odin/examples/ContramapExample.scala
+++ b/examples/src/main/scala/io/odin/examples/ContramapExample.scala
@@ -1,6 +1,6 @@
 package io.odin.examples
 
-import cats.effect.{ExitCode, IO, IOApp}
+import cats.effect.{IO, IOApp}
 import cats.syntax.all._
 import io.odin._
 import io.odin.syntax._
@@ -8,13 +8,13 @@ import io.odin.syntax._
 /**
   * Modify logger message before it's written
   */
-object ContramapExample extends IOApp {
+object ContramapExample extends IOApp.Simple {
 
   /**
     * This logger always appends " World" string to each message
     */
   def logger: Logger[IO] = consoleLogger[IO]().contramap(msg => msg.copy(message = msg.message.map(_ + " World")))
 
-  def run(args: List[String]): IO[ExitCode] =
-    logger.info("Hello").as(ExitCode.Success)
+  def run: IO[Unit] =
+    logger.info("Hello")
 }

--- a/examples/src/main/scala/io/odin/examples/EnclosureBasedRouting.scala
+++ b/examples/src/main/scala/io/odin/examples/EnclosureBasedRouting.scala
@@ -1,6 +1,6 @@
 package io.odin.examples
 
-import cats.effect.{ExitCode, IO, IOApp}
+import cats.effect.{IO, IOApp}
 import io.odin._
 import io.odin.config._
 
@@ -9,7 +9,7 @@ import io.odin.config._
   *
   * Mind that match is done in order of definition, therefore the most specific routes should always appear on top
   */
-object EnclosureBasedRouting extends IOApp {
+object EnclosureBasedRouting extends IOApp.Simple {
   val logger: Logger[IO] =
     enclosureRouting(
       "io.odin.examples.EnclosureBasedRouting.foo" -> consoleLogger[IO]().withMinimalLevel(Level.Warn),
@@ -21,7 +21,7 @@ object EnclosureBasedRouting extends IOApp {
   def foo: IO[Unit] = logger.info("Never shown")
   def bar: IO[Unit] = logger.warn("Warning")
 
-  def run(args: List[String]): IO[ExitCode] = {
-    (zoo *> foo *> bar).as(ExitCode.Success)
+  def run: IO[Unit] = {
+    (zoo *> foo *> bar)
   }
 }

--- a/examples/src/main/scala/io/odin/examples/FilteringStackTrace.scala
+++ b/examples/src/main/scala/io/odin/examples/FilteringStackTrace.scala
@@ -1,6 +1,6 @@
 package io.odin.examples
 
-import cats.effect.{ExitCode, IO, IOApp}
+import cats.effect.{IO, IOApp}
 import io.odin._
 import io.odin.formatter.Formatter
 import io.odin.formatter.options.ThrowableFormat
@@ -27,7 +27,7 @@ import io.odin.formatter.options.ThrowableFormat
   * io.odin.examples.FilteringStackTrace$.main(FilteringStackTrace.scala:30)
   * io.odin.examples.FilteringStackTrace.main(FilteringStackTrace.scala)
   */
-object FilteringStackTrace extends IOApp {
+object FilteringStackTrace extends IOApp.Simple {
   val throwableFormat: ThrowableFormat = ThrowableFormat(
     ThrowableFormat.Depth.Fixed(3),
     ThrowableFormat.Indent.NoIndent,
@@ -35,6 +35,6 @@ object FilteringStackTrace extends IOApp {
   )
   val logger: Logger[IO] = consoleLogger(formatter = Formatter.create(throwableFormat, colorful = true))
 
-  def run(args: List[String]): IO[ExitCode] =
-    logger.error("This is an exception", new RuntimeException("here")).as(ExitCode.Success)
+  def run: IO[Unit] =
+    logger.error("This is an exception", new RuntimeException("here"))
 }

--- a/examples/src/main/scala/io/odin/examples/HelloWorld.scala
+++ b/examples/src/main/scala/io/odin/examples/HelloWorld.scala
@@ -1,15 +1,15 @@
 package io.odin.examples
 
-import cats.effect.{ExitCode, IO, IOApp}
+import cats.effect.{IO, IOApp}
 import io.odin._
 import io.odin.formatter.Formatter
 
 /**
   * Prints simple `Hello World` log line
   */
-object HelloWorld extends IOApp {
+object HelloWorld extends IOApp.Simple {
   val logger: Logger[IO] = consoleLogger(formatter = Formatter.colorful)
 
-  def run(args: List[String]): IO[ExitCode] =
-    logger.info("Hello world").as(ExitCode.Success)
+  def run: IO[Unit] =
+    logger.info("Hello world")
 }

--- a/examples/src/main/scala/io/odin/examples/MinLevelExample.scala
+++ b/examples/src/main/scala/io/odin/examples/MinLevelExample.scala
@@ -1,15 +1,15 @@
 package io.odin.examples
 
-import cats.effect.{ExitCode, IO, IOApp}
+import cats.effect.{IO, IOApp}
 import io.odin.{Logger, _}
 
 /**
   * Only warning message will be printed to the STDERR since this logger defines minimal level
   */
-object MinLevelExample extends IOApp {
+object MinLevelExample extends IOApp.Simple {
   val logger: Logger[IO] = consoleLogger[IO]().withMinimalLevel(Level.Warn)
 
-  def run(args: List[String]): IO[ExitCode] = {
-    (logger.info("Hello?") *> logger.warn("Hi there")).as(ExitCode.Success)
+  def run: IO[Unit] = {
+    (logger.info("Hello?") *> logger.warn("Hi there"))
   }
 }

--- a/examples/src/main/scala/io/odin/examples/SimpleApp.scala
+++ b/examples/src/main/scala/io/odin/examples/SimpleApp.scala
@@ -1,7 +1,7 @@
 package io.odin.examples
 
 import cats.Applicative
-import cats.effect.{ExitCode, IO, IOApp}
+import cats.effect.{IO, IOApp}
 import cats.syntax.all._
 import io.odin._
 import io.odin.formatter.Formatter
@@ -12,7 +12,7 @@ import io.odin.formatter.Formatter
   *
   * When application runs it prints out greeting along with log of the `simpleService.greet` call.
   */
-object SimpleApp extends IOApp {
+object SimpleApp extends IOApp.Simple {
 
   private val logger: Logger[IO] = consoleLogger(formatter = Formatter.colorful)
 
@@ -20,8 +20,8 @@ object SimpleApp extends IOApp {
 
   def greetUser(name: String): IO[String] = simpleService.greet(name)
 
-  def run(args: List[String]): IO[ExitCode] = {
-    greetUser("Viking").map(println(_)).as(ExitCode.Success)
+  def run: IO[Unit] = {
+    greetUser("Viking").map(println(_))
   }
 }
 

--- a/examples/src/main/scala/io/odin/examples/WithConstContext.scala
+++ b/examples/src/main/scala/io/odin/examples/WithConstContext.scala
@@ -1,15 +1,15 @@
 package io.odin.examples
 
-import cats.effect.{ExitCode, IO, IOApp}
+import cats.effect.{IO, IOApp}
 import io.odin._
 import io.odin.syntax._
 
 /**
   * Prints `Hello World` log line with some predefined constant context
   */
-object WithConstContext extends IOApp {
+object WithConstContext extends IOApp.Simple {
   val logger: Logger[IO] = consoleLogger[IO]().withConstContext(Map("this is" -> "context"))
 
-  def run(args: List[String]): IO[ExitCode] =
-    logger.info("Hello world").as(ExitCode.Success)
+  def run: IO[Unit] =
+    logger.info("Hello world")
 }

--- a/examples/src/main/scala/io/odin/examples/WithContextual.scala
+++ b/examples/src/main/scala/io/odin/examples/WithContextual.scala
@@ -1,7 +1,7 @@
 package io.odin.examples
 
 import cats.data.ReaderT
-import cats.effect.{ExitCode, IO, IOApp}
+import cats.effect.{IO, IOApp}
 import io.odin._
 import io.odin.formatter.Formatter
 import io.odin.loggers.HasContext
@@ -14,7 +14,7 @@ import io.odin.syntax._
   * environment `Env` defined, `withContext` will automatically derive required type classes for adding the context to
   * the log
   */
-object WithContextual extends IOApp {
+object WithContextual extends IOApp.Simple {
 
   /**
     * Simple Reader monad with environment being context `Map[String, String]`
@@ -32,6 +32,6 @@ object WithContextual extends IOApp {
     */
   val logger: Logger[F] = consoleLogger[F](formatter = Formatter.colorful).withContext
 
-  def run(args: List[String]): IO[ExitCode] =
-    logger.info("Hello world").run(Map("this is" -> "context")).as(ExitCode.Success)
+  def run: IO[Unit] =
+    logger.info("Hello world").run(Map("this is" -> "context"))
 }

--- a/examples/src/main/scala/io/odin/examples/ZIOHelloWorld.scala
+++ b/examples/src/main/scala/io/odin/examples/ZIOHelloWorld.scala
@@ -1,4 +1,5 @@
 package io.odin.examples
+/*
 
 import io.odin.Logger
 import zio._
@@ -10,3 +11,4 @@ object ZIOHelloWorld extends App {
   def run(args: List[String]): URIO[zio.ZEnv, ExitCode] =
     logger.info("Hello world").fold(_ => ExitCode.failure, _ => ExitCode.success)
 }
+*/

--- a/examples/src/main/scala/io/odin/examples/ZIOHelloWorld.scala
+++ b/examples/src/main/scala/io/odin/examples/ZIOHelloWorld.scala
@@ -11,4 +11,4 @@ object ZIOHelloWorld extends App {
   def run(args: List[String]): URIO[zio.ZEnv, ExitCode] =
     logger.info("Hello world").fold(_ => ExitCode.failure, _ => ExitCode.success)
 }
-*/
+ */

--- a/examples/src/main/scala/io/odin/examples/ZIOHelloWorld.scala
+++ b/examples/src/main/scala/io/odin/examples/ZIOHelloWorld.scala
@@ -1,14 +1,12 @@
 package io.odin.examples
-/*
 
 import io.odin.Logger
 import zio._
 import io.odin.zio._
 
 object ZIOHelloWorld extends App {
-  val logger: Logger[IO[LoggerError, *]] = consoleLogger()
+  val logger: Logger[IO[LoggerError, *]] = consoleLogger()(this)
 
   def run(args: List[String]): URIO[zio.ZEnv, ExitCode] =
     logger.info("Hello world").fold(_ => ExitCode.failure, _ => ExitCode.success)
 }
- */

--- a/examples/src/test/scala/io/odin/examples/SimpleAppSpec.scala
+++ b/examples/src/test/scala/io/odin/examples/SimpleAppSpec.scala
@@ -1,7 +1,8 @@
 package io.odin.examples
 
 import cats.data.WriterT
-import cats.effect.{IO, Timer}
+import cats.effect.IO
+import cats.effect.unsafe.IORuntime
 import io.odin.{Logger, LoggerMessage, OdinSpec}
 import io.odin.loggers.WriterTLogger
 
@@ -12,7 +13,7 @@ class SimpleAppSpec extends OdinSpec {
 
   //definition of test monad. It keeps all the incoming `LoggerMessage` inside of the list
   type WT[A] = WriterT[IO, List[LoggerMessage], A]
-  implicit val timer: Timer[IO] = IO.timer(scala.concurrent.ExecutionContext.global)
+  implicit val ioRuntime: IORuntime = IORuntime.global
 
   "HelloSimpleService" should "log greeting call" in {
     //logger that writes messages as a log of WriterT monad

--- a/extras/src/main/scala/io/odin/extras/loggers/ConditionalLogger.scala
+++ b/extras/src/main/scala/io/odin/extras/loggers/ConditionalLogger.scala
@@ -38,7 +38,7 @@ final case class ConditionalLogger[F[_]: Clock] private (
     F.tailRecM(Vector.empty[LoggerMessage]) { acc =>
       queue.tryTake.map {
         case Some(value) => Left(acc :+ value)
-        case None => Right(acc)
+        case None        => Right(acc)
       }
     }
 

--- a/extras/src/main/scala/io/odin/extras/syntax/package.scala
+++ b/extras/src/main/scala/io/odin/extras/syntax/package.scala
@@ -1,6 +1,6 @@
 package io.odin.extras
 
-import cats.effect.{Clock, Concurrent, ContextShift}
+import cats.effect.kernel.Async
 import io.odin.extras.loggers.ConditionalLogger
 import io.odin.{Level, Logger}
 
@@ -18,7 +18,7 @@ package object syntax {
     def withErrorLevel[A](
         minLevelOnError: Level,
         maxBufferSize: Option[Int] = None
-    )(use: Logger[F] => F[A])(implicit clock: Clock[F], F: Concurrent[F], contextShift: ContextShift[F]): F[A] =
+    )(use: Logger[F] => F[A])(implicit F: Async[F]): F[A] =
       ConditionalLogger.create[F](logger, minLevelOnError, maxBufferSize).use(use)
 
   }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.4.7
+sbt.version=1.4.9

--- a/slf4j/src/main/scala/io/odin/slf4j/OdinLoggerAdapter.scala
+++ b/slf4j/src/main/scala/io/odin/slf4j/OdinLoggerAdapter.scala
@@ -1,7 +1,7 @@
 package io.odin.slf4j
 
 import cats.Eval
-import cats.effect.kernel.{Clock, Sync}
+import cats.effect.kernel.Sync
 import cats.effect.std.Dispatcher
 import cats.syntax.all._
 import io.odin.meta.Position

--- a/slf4j/src/main/scala/io/odin/slf4j/OdinLoggerAdapter.scala
+++ b/slf4j/src/main/scala/io/odin/slf4j/OdinLoggerAdapter.scala
@@ -10,9 +10,8 @@ import org.slf4j.Logger
 import org.slf4j.helpers.{FormattingTuple, MarkerIgnoringBase, MessageFormatter}
 
 case class OdinLoggerAdapter[F[_]](loggerName: String, underlying: OdinLogger[F])(
-  implicit F: Sync[F],
-  clock: Clock[F],
-  dispatcher: Dispatcher[F]
+    implicit F: Sync[F],
+    dispatcher: Dispatcher[F]
 ) extends MarkerIgnoringBase
     with Logger {
 
@@ -20,26 +19,26 @@ case class OdinLoggerAdapter[F[_]](loggerName: String, underlying: OdinLogger[F]
 
   private def run(level: Level, msg: String, t: Option[Throwable] = None): Unit =
     dispatcher.unsafeRunSync(for {
-        timestamp <- clock.realTime
-        _ <- underlying.log(
-          LoggerMessage(
-            level = level,
-            message = Eval.now(msg),
-            context = Map.empty,
-            exception = t,
-            position = Position(
-              fileName = loggerName,
-              enclosureName = loggerName,
-              packageName = loggerName,
-              line = -1
-            ),
-            threadName = Thread.currentThread().getName,
-            timestamp = timestamp.toMillis
-          )
+      timestamp <- F.realTime
+      _ <- underlying.log(
+        LoggerMessage(
+          level = level,
+          message = Eval.now(msg),
+          context = Map.empty,
+          exception = t,
+          position = Position(
+            fileName = loggerName,
+            enclosureName = loggerName,
+            packageName = loggerName,
+            line = -1
+          ),
+          threadName = Thread.currentThread().getName,
+          timestamp = timestamp.toMillis
         )
-      } yield {
-        ()
-      })
+      )
+    } yield {
+      ()
+    })
 
   private def runFormatted(level: Level, tuple: FormattingTuple): Unit =
     run(level, tuple.getMessage, Option(tuple.getThrowable))

--- a/slf4j/src/main/scala/io/odin/slf4j/OdinLoggerBinder.scala
+++ b/slf4j/src/main/scala/io/odin/slf4j/OdinLoggerBinder.scala
@@ -1,14 +1,15 @@
 package io.odin.slf4j
 
-import cats.effect.{Clock, Effect}
+import cats.effect.kernel.Sync
+import cats.effect.std.Dispatcher
 import io.odin.Logger
 import org.slf4j.ILoggerFactory
 import org.slf4j.spi.LoggerFactoryBinder
 
 abstract class OdinLoggerBinder[F[_]] extends LoggerFactoryBinder {
 
-  implicit def clock: Clock[F]
-  implicit def F: Effect[F]
+  implicit def F: Sync[F]
+  implicit def dispatcher: Dispatcher[F]
 
   def loggers: PartialFunction[String, Logger[F]]
 

--- a/slf4j/src/main/scala/io/odin/slf4j/OdinLoggerFactory.scala
+++ b/slf4j/src/main/scala/io/odin/slf4j/OdinLoggerFactory.scala
@@ -1,10 +1,11 @@
 package io.odin.slf4j
 
-import cats.effect.{Clock, Effect}
+import cats.effect.kernel.Sync
+import cats.effect.std.Dispatcher
 import io.odin.{Logger => OdinLogger}
 import org.slf4j.{ILoggerFactory, Logger}
 
-class OdinLoggerFactory[F[_]: Effect: Clock](loggers: PartialFunction[String, OdinLogger[F]]) extends ILoggerFactory {
+class OdinLoggerFactory[F[_]: Sync: Dispatcher](loggers: PartialFunction[String, OdinLogger[F]]) extends ILoggerFactory {
   def getLogger(name: String): Logger = {
     new OdinLoggerAdapter[F](name, loggers.applyOrElse(name, (_: String) => OdinLogger.noop))
   }

--- a/slf4j/src/main/scala/io/odin/slf4j/OdinLoggerFactory.scala
+++ b/slf4j/src/main/scala/io/odin/slf4j/OdinLoggerFactory.scala
@@ -5,7 +5,8 @@ import cats.effect.std.Dispatcher
 import io.odin.{Logger => OdinLogger}
 import org.slf4j.{ILoggerFactory, Logger}
 
-class OdinLoggerFactory[F[_]: Sync: Dispatcher](loggers: PartialFunction[String, OdinLogger[F]]) extends ILoggerFactory {
+class OdinLoggerFactory[F[_]: Sync: Dispatcher](loggers: PartialFunction[String, OdinLogger[F]])
+    extends ILoggerFactory {
   def getLogger(name: String): Logger = {
     new OdinLoggerAdapter[F](name, loggers.applyOrElse(name, (_: String) => OdinLogger.noop))
   }

--- a/slf4j/src/test/scala/io/odin/slf4j/BufferingLogger.scala
+++ b/slf4j/src/test/scala/io/odin/slf4j/BufferingLogger.scala
@@ -1,6 +1,6 @@
 package io.odin.slf4j
 
-import cats.effect.concurrent.Ref
+import cats.effect.kernel.Ref
 import cats.effect.{Clock, Sync}
 import io.odin.loggers.DefaultLogger
 import io.odin.{Level, Logger, LoggerMessage}

--- a/slf4j/src/test/scala/io/odin/slf4j/ExternalLogger.scala
+++ b/slf4j/src/test/scala/io/odin/slf4j/ExternalLogger.scala
@@ -1,11 +1,14 @@
 package io.odin.slf4j
 
-import cats.effect.{Clock, Effect, IO}
+import cats.effect.IO
+import cats.effect.kernel.Sync
+import cats.effect.std.Dispatcher
+import cats.effect.unsafe.implicits.global
 import io.odin.{Level, Logger}
 
 class ExternalLogger extends OdinLoggerBinder[IO] {
-  implicit val F: Effect[IO] = IO.ioEffect
-  implicit val clock: Clock[IO] = Clock.create
+  implicit val F: Sync[IO] = IO.asyncForIO
+  implicit val dispatcher: Dispatcher[IO] = Dispatcher[IO].allocated.unsafeRunSync()._1
 
   val loggers: PartialFunction[String, Logger[IO]] = {
     case Level.Trace.toString => new BufferingLogger[IO](Level.Trace)

--- a/slf4j/src/test/scala/io/odin/slf4j/Slf4jSpec.scala
+++ b/slf4j/src/test/scala/io/odin/slf4j/Slf4jSpec.scala
@@ -2,13 +2,16 @@ package io.odin.slf4j
 
 import cats.syntax.all._
 import cats.effect.IO
-import cats.effect.concurrent.Ref
+import cats.effect.kernel.Ref
+import cats.effect.unsafe.IORuntime
 import io.odin.{Level, LoggerMessage, OdinSpec}
 import org.slf4j.{Logger, LoggerFactory}
 
 import scala.collection.immutable.Queue
 
 class Slf4jSpec extends OdinSpec {
+
+  private implicit val ioRuntime: IORuntime = IORuntime.global
 
   it should "log with correct level" in {
     forAll { msgs: List[LoggerMessage] =>

--- a/slf4j/src/test/scala/io/odin/slf4j/Slf4jSpec.scala
+++ b/slf4j/src/test/scala/io/odin/slf4j/Slf4jSpec.scala
@@ -11,7 +11,7 @@ import scala.collection.immutable.Queue
 
 class Slf4jSpec extends OdinSpec {
 
-  private implicit val ioRuntime: IORuntime = IORuntime.global
+  implicit private val ioRuntime: IORuntime = IORuntime.global
 
   it should "log with correct level" in {
     forAll { msgs: List[LoggerMessage] =>


### PR DESCRIPTION
Temporarily disabled modules: ~~`odin-zio`~~, `odin-monix`
Missing CE3 dependencies: ~~`zio-cats`~~, `monix`

`odin-core` depends on `cats-effect-std`.

Changes due to missing Monix dependency:
- Replaced `ConcurrentQueue` from Monix with `Queue` from `cats.effect.std`
- Replaced `monix.Task` with `cats.effect.IO` in tests
- Removed `monix.execution.Scheduler` in favor of `IORuntime`

Once a compatible version of Monix will be released, I can revert these changes.

# Benchmarks

I observed a performance degradation after the upgrade to CE3.  Evaluating a task via `.unsafeRunSync()` in a for-loop is 3x slower comparing to the CE2. Using `traverse` instead of a for-loop leads to more clear results.

## for-loop 

The results below represent the evaluation of a logging effect in a for-loop. Example:
```scala
@Benchmark
@OperationsPerInvocation(1000)
def msg(): Unit = for (_ <- 1 to 1000) logger.info(message).unsafeRunSync()
```

| Benchmark                            | Mode | Cnt | Score     | Error      | Units |
|--------------------------------------|------|-----|----------:|-----------:|-------|
| FileLoggerBenchmarks.msg             | avgt |  25   | 21488.981 | ± 1462.785 | ns/op |
| FileLoggerBenchmarks.msgAndCtx       | avgt | 25  | 20273.076 | ± 695.874  | ns/op |
| FileLoggerBenchmarks.msgCtxThrowable | avgt | 25  | 30110.791 | ± 1010.558 | ns/op |
|                                      |      |     |           |            |       |
| AsyncLoggerBenchmark.msg             | avgt | 25  | 18097.440 | ± 4621.083 | ns/op |
| AsyncLoggerBenchmark.msgAndCtx       | avgt | 25  | 14337.669 | ± 1383.534 | ns/op |
| AsyncLoggerBenchmark.msgCtxThrowable | avgt | 25  | 17652.329 | ± 1098.268 | ns/op |
|                                      |      |     |           |            |       |
| ScribeBenchmark.asyncMsg             | avgt | 25  | 114.641   | ± 3.568    | ns/op |
| ScribeBenchmark.asyncMsgCtx          | avgt | 25  | 131.083   | ± 2.123    | ns/op |
| ScribeBenchmark.msg                  | avgt | 25  | 1443.887  | ± 34.406   | ns/op |
| ScribeBenchmark.msgAndCtx            | avgt | 25  | 1717.407  | ± 50.303   | ns/op |

## traverse

```scala
@Benchmark
@OperationsPerInvocation(1000)
def msg(): Unit = (1 to 1000).toList.traverse(_ => logger.info(message)).unsafeRunSync()
```

| Benchmark                            | Mode | Cnt | Score     | Error      | Units |
|--------------------------------------|------|-----|-----------:|------------:|-------|
| FileLoggerBenchmarks.msg             | avgt | 25  | 7750.887  | ± 456.193  | ns/op |
| FileLoggerBenchmarks.msgAndCtx       | avgt | 25  | 8385.711  | ± 585.243  | ns/op |
| FileLoggerBenchmarks.msgCtxThrowable | avgt | 25  | 21720.537 | ± 4569.168 | ns/op |
|                                      |      |     |           |            |       |
| AsyncLoggerBenchmark.msg             | avgt | 25  | 1486.737  | ± 271.336  | ns/op |
| AsyncLoggerBenchmark.msgAndCtx       | avgt | 25  | 1523.111  | ± 211.884  | ns/op |
| AsyncLoggerBenchmark.msgCtxThrowable | avgt | 25  | 1624.252  | ± 170.380  | ns/op |

# AsyncLoggerBenchmark issue

From my point of view, the async logger benchmark implemented in a bit wrong way. And it does not measure the real throughput.

The key element of the `AsyncLogger` is a Queue. Logging a message, basically, an enqueue operation:
```scala
def submit(msg: LoggerMessage): F[Unit] = {
  queue.tryOffer(msg).void
}
```

In benchmarks, the size of a queue is `1_000_000` elements and the flush period is `1 millisecond`.  Since the JMH executes the code thousands of times, the queue is populated up to the limit almost immediately. Hence the `tryOffer` method does nothing during evaluation:

```scala
def tryOffer(a: A): F[Boolean] =
  state
    .modify {
      case State(queue, size, takers, offerers) if takers.nonEmpty =>
        val (taker, rest) = takers.dequeue
        State(queue, size, rest, offerers) -> taker.complete(a).as(true)
      case State(queue, size, takers, offerers) if size < capacity =>
        State(queue.enqueue(a), size + 1, takers, offerers) -> F.pure(true)
      case s => 
         s -> F.pure(false) <- the branch being evaluated when the queue is full
    }
    .flatten
    .uncancelable
```

To prove my assumption I changed the logic of the background fiber:
```diff
def runF: F[Fiber[F, Throwable, Unit]] = {
-  def drainLoop: F[Unit] = drain >> F.sleep(timeWindow) >> F.cede >> drainLoop
+  def drainLoop: F[Unit] = F.unit

  F.start(drainLoop).map { fiber =>
    new Fiber[F, Throwable, Unit] {
      override def cancel: F[Unit] = drain >> fiber.cancel
      override def join: F[Outcome[F, Throwable, Unit]] = fiber.join
    }
  }
}
```

The queue never being drained and `tryOffer` does nothing. And the measurements became similar to the CE2 version:

| Benchmark                            | Mode | Cnt | Score     | Error      | Units |
|--------------------------------------|------|-----|-----------:|------------:|-------|
| AsyncLoggerBenchmark.msg             | avgt | 25  | 996.862   | ± 393.928  | ns/op |
| AsyncLoggerBenchmark.msgAndCtx       | avgt | 25  | 710.134   | ± 134.316  | ns/op |
| AsyncLoggerBenchmark.msgCtxThrowable | avgt | 25  | 741.075   | ± 195.111  | ns/op |
