### PR TITLE
Change log level handling for single log messages

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -28,6 +28,8 @@ lazy val scalaVersions = scala2 ::: scala3
 lazy val scalaTest = "org.scalatest" %% "scalatest" % versions.scalaTest % Test
 lazy val scalaTestScalaCheck = "org.scalatestplus" %% "scalacheck-1-15" % versions.scalaTestScalaCheck % Test
 
+lazy val alleycats = "org.typelevel" %% "alleycats-core" % versions.cats
+
 lazy val cats = List(
   (version: String) => "org.typelevel" %% "cats-core" % version,
   (version: String) => "org.typelevel" %% "cats-laws" % version % Test
@@ -113,7 +115,7 @@ lazy val sharedSettings = Seq(
 lazy val `odin-core` = (project in file("core"))
   .settings(sharedSettings)
   .settings(
-    libraryDependencies ++= (catsEffect % Test) :: catsMtl :: sourcecode :: perfolation :: catsEffectStd :: cats
+    libraryDependencies ++= (catsEffect % Test) :: catsMtl :: sourcecode :: perfolation :: catsEffectStd :: alleycats :: cats
   )
 
 lazy val `odin-json` = (project in file("json"))

--- a/core/src/main/scala/io/odin/config/EnclosureRouting.scala
+++ b/core/src/main/scala/io/odin/config/EnclosureRouting.scala
@@ -1,5 +1,6 @@
 package io.odin.config
 
+import alleycats.std.iterable._
 import cats.Monad
 import cats.effect.kernel.Clock
 import cats.syntax.all._
@@ -19,23 +20,22 @@ private[config] class EnclosureRouting[F[_]: Clock](fallback: Logger[F], router:
   def submit(msg: LoggerMessage): F[Unit] = recLog(indexedRouter, msg)
 
   override def submit(msgs: List[LoggerMessage]): F[Unit] = {
-    msgs
-      .map { msg =>
-        indexedRouter
-          .collectFirst {
-            case (key, indexedLogger) if msg.position.enclosureName.startsWith(key) => indexedLogger
-          }
-          .getOrElse(-1 -> fallback) -> List(msg)
-      }
+    val grouped: Iterable[((Int, Logger[F]), List[LoggerMessage])] = msgs
       .foldLeft(Map.empty[(Int, Logger[F]), List[LoggerMessage]]) {
-        case (map, kv) =>
+        case (map, msg) =>
+          val kv = indexedRouter
+            .collectFirst {
+              case (key, indexedLogger) if msg.position.enclosureName.startsWith(key) => indexedLogger
+            }
+            .getOrElse(-1 -> fallback) -> List(msg)
+
           map |+| Map(kv)
       }
-      .toList
-      .traverse_ {
-        case ((_, logger), ms) =>
-          logger.log(ms.filter(_.level >= logger.minLevel))
-      }
+
+    grouped.traverse_ {
+      case ((_, logger), ms) =>
+        logger.log(ms.filter(_.level >= logger.minLevel))
+    }
   }
 
   @tailrec

--- a/core/src/main/scala/io/odin/config/EnclosureRouting.scala
+++ b/core/src/main/scala/io/odin/config/EnclosureRouting.scala
@@ -43,8 +43,8 @@ private[config] class EnclosureRouting[F[_]: Clock](fallback: Logger[F], router:
     case Nil =>
       if (msg.level >= fallback.minLevel) fallback.log(msg)
       else F.unit
-    case (key, (_, logger)) :: _ if msg.position.enclosureName.startsWith(key) && msg.level >= logger.minLevel =>
-      logger.log(msg)
+    case (key, (_, logger)) :: _ if msg.position.enclosureName.startsWith(key) =>
+      F.whenA(msg.level >= logger.minLevel)(logger.log(msg))
     case _ :: tail => recLog(tail, msg)
   }
 


### PR DESCRIPTION
Maybe I've missed something, but I noticed when using `EnclosureRouting` and logging single messages that messages fall through to the fallback logger as if the enclosure hasn't matched. This attempts to fix this behvaiour and make it consistent with the method which takes multiple log messages.

I've also (in a separate commit) optimised the `submit` method that takes multiple log messages, removing a couple of traversals. It introduces a depdendency on alleycats, I hope this is ok!