### PR TITLE
AsyncLogger: enqueue logging operation instead of a log message

### DIFF
--- a/core/src/test/scala/io/odin/loggers/AsyncLoggerSpec.scala
+++ b/core/src/test/scala/io/odin/loggers/AsyncLoggerSpec.scala
@@ -1,6 +1,6 @@
 package io.odin.loggers
 
-import cats.effect.std.Queue
+import cats.effect.std.{Queue, Semaphore}
 import cats.effect.unsafe.IORuntime
 import cats.effect.{IO, Ref, Resource}
 import cats.syntax.all._
@@ -10,12 +10,14 @@ import io.odin.{Level, Logger, LoggerMessage, OdinSpec}
 import scala.concurrent.duration._
 
 class AsyncLoggerSpec extends OdinSpec {
+  import AsyncLoggerSpec._
 
   implicit private val ioRuntime: IORuntime = IORuntime.global
 
   case class RefLogger(ref: Ref[IO, List[LoggerMessage]], override val minLevel: Level = Level.Trace)
       extends DefaultLogger[IO](minLevel) {
-    def submit(msg: LoggerMessage): IO[Unit] = IO.raiseError(new IllegalStateException("Async should always batch"))
+    def submit(msg: LoggerMessage): IO[Unit] =
+      ref.update(_ :+ msg)
 
     override def submit(msgs: List[LoggerMessage]): IO[Unit] = {
       ref.update(_ ::: msgs)
@@ -41,10 +43,9 @@ class AsyncLoggerSpec extends OdinSpec {
   it should "push logs to the queue" in {
     forAll { (msgs: List[LoggerMessage]) =>
       (for {
-        queue <- Queue.unbounded[IO, LoggerMessage]
-        logger = AsyncLogger(queue, 1.millis, Logger.noop[IO]).withMinimalLevel(Level.Trace)
-        _ <- msgs.traverse(logger.log)
-        reported <- List.fill(msgs.length)(queue.take).sequence
+        queueLogger <- createQueueLogger(Level.Trace)
+        _ <- queueLogger.withAsync(1.millis).use(logger => msgs.traverse(logger.log))
+        reported <- queueLogger.take(msgs.size)
       } yield {
         reported shouldBe msgs
       }).unsafeRunSync()
@@ -59,8 +60,9 @@ class AsyncLoggerSpec extends OdinSpec {
     }
     forAll { (msgs: List[LoggerMessage]) =>
       (for {
-        queue <- Queue.unbounded[IO, LoggerMessage]
-        logger = AsyncLogger(queue, 1.millis, errorLogger)
+        queue <- Queue.unbounded[IO, IO[Unit]]
+        sem <- Semaphore[IO](1)
+        logger = AsyncLogger(queue, sem, 1.millis, errorLogger)
         _ <- logger.log(msgs)
         result <- logger.drain
       } yield {
@@ -68,4 +70,46 @@ class AsyncLoggerSpec extends OdinSpec {
       }).unsafeRunSync()
     }
   }
+
+  it should "respect updated minimal level" in {
+    forAll { (msgs: List[LoggerMessage]) =>
+      (for {
+        queueLogger <- createQueueLogger(Level.Info)
+        infoMessages <- IO.pure(msgs.filter(_.level >= Level.Info))
+        _ <- queueLogger.withAsync(timeWindow = 1.millis).use { logger =>
+          val traceLogger = logger.withMinimalLevel(Level.Trace)
+
+          for {
+            _ <- msgs.traverse(logger.log) // only Info, Warn, Error messages should be logged
+            _ <- msgs.traverse(traceLogger.log) // all messages should be logged
+          } yield ()
+        }
+        info <- queueLogger.take(infoMessages.size)
+        reported <- queueLogger.take(msgs.size)
+      } yield {
+        info shouldBe infoMessages
+        reported shouldBe msgs
+      }).unsafeRunSync()
+    }
+  }
+
+  private def createQueueLogger(minLevel: Level): IO[QueueLogger] =
+    for {
+      queue <- Queue.unbounded[IO, LoggerMessage]
+    } yield QueueLogger(queue, minLevel)
+}
+
+object AsyncLoggerSpec {
+
+  case class QueueLogger(queue: Queue[IO, LoggerMessage], level: Level) extends DefaultLogger[IO](level) {
+    def submit(msg: LoggerMessage): IO[Unit] =
+      queue.offer(msg)
+
+    def withMinimalLevel(level: Level): Logger[IO] =
+      copy(level = level)
+
+    def take(count: Int): IO[List[LoggerMessage]] =
+      queue.take.replicateA(count)
+  }
+
 }


### PR DESCRIPTION
My attempt to fix https://github.com/valskalla/odin/issues/460.

This approach fixes the underlying issue, but it affects the performance as well.

### 1) AsyncLoggerBenchmark

Original benchmarks of async logger are a little bit of cheating. Since they are basically measuring the `queue.offer` operation. 

**Before (master branch):**
```
Benchmark                             Mode  Cnt    Score     Error  Units
AsyncLoggerBenchmark.msg              avgt   25  1241.937 ±  276.487  ns/op
AsyncLoggerBenchmark.msgAndCtx        avgt   25  1274.021 ±   82.916  ns/op
AsyncLoggerBenchmark.msgCtxThrowable  avgt   25  2021.246 ± 1326.558  ns/op
```

**After (fix branch):**
```
Benchmark                             Mode  Cnt    Score     Error  Units
AsyncLoggerBenchmark.msg              avgt   25  699.431 ±  73.839  ns/op
AsyncLoggerBenchmark.msgAndCtx        avgt   25  716.672 ± 105.136  ns/op
AsyncLoggerBenchmark.msgCtxThrowable  avgt   25  926.306 ± 568.412  ns/op
```

### 2) Measure the cost of the `drain` operation

I decided to measure the cost of the `drain` operation as well. I tweaked `AsyncLoggerBenchmark` for this purpose:
```diff
val (asyncLogger: Logger[IO], cancelToken: IO[Unit]) =
  fileLogger[IO](fileName).withAsync(
+   timeWindow = Int.MaxValue.seconds, // to prevent background flushes
    maxBufferSize = Some(1000000)
  ).allocated.unsafeRunSync()
    
@Benchmark
@OperationsPerInvocation(1000)
def msg(): Unit = 
  (1 to 1000).toList.traverse(_ => asyncLogger.info(message))
+   .flatMap(_ => asyncLogger.drain) 
    .unsafeRunSync()
```

**Before (master branch):**
```
Benchmark                             Mode  Cnt     Score    Error  Units
AsyncLoggerBenchmark.msg              avgt   25  1021.347 ± 32.193  ns/op
AsyncLoggerBenchmark.msgAndCtx        avgt   25  1013.955 ± 68.780  ns/op
AsyncLoggerBenchmark.msgCtxThrowable  avgt   25  4804.478 ± 99.426  ns/op
```

**After (fix branch):**
```
Benchmark                             Mode  Cnt     Score     Error  Units
AsyncLoggerBenchmark.msg              avgt   25  3483.380 ± 125.855  ns/op
AsyncLoggerBenchmark.msgAndCtx        avgt   25  3478.960 ±  95.501  ns/op
AsyncLoggerBenchmark.msgCtxThrowable  avgt   25  7026.014 ± 107.790  ns/op
```