### PR TITLE
Use `Option(t)` instead of `Some(t)`

### DIFF
--- a/core/src/main/scala/io/odin/loggers/DefaultLogger.scala
+++ b/core/src/main/scala/io/odin/loggers/DefaultLogger.scala
@@ -48,7 +48,7 @@ abstract class DefaultLogger[F[_]](val minLevel: Level)(implicit clock: Clock[F]
 
   def trace[M, E](msg: => M, e: E)(implicit render: Render[M], tt: ToThrowable[E], position: Position): F[Unit] =
     F.whenA(minLevel <= Level.Trace) {
-      log(Level.Trace, msg, t = Some(tt.throwable(e)))
+      log(Level.Trace, msg, t = Option(tt.throwable(e)))
     }
 
   def trace[M](msg: => M, ctx: Map[String, String])(implicit render: Render[M], position: Position): F[Unit] =
@@ -62,7 +62,7 @@ abstract class DefaultLogger[F[_]](val minLevel: Level)(implicit clock: Clock[F]
       position: Position
   ): F[Unit] =
     F.whenA(minLevel <= Level.Trace) {
-      log(Level.Trace, msg, ctx, Some(tt.throwable(e)))
+      log(Level.Trace, msg, ctx, Option(tt.throwable(e)))
     }
 
   def debug[M](msg: => M)(implicit render: Render[M], position: Position): F[Unit] =
@@ -72,7 +72,7 @@ abstract class DefaultLogger[F[_]](val minLevel: Level)(implicit clock: Clock[F]
 
   def debug[M, E](msg: => M, e: E)(implicit render: Render[M], tt: ToThrowable[E], position: Position): F[Unit] =
     F.whenA(minLevel <= Level.Debug) {
-      log(Level.Debug, msg, t = Some(tt.throwable(e)))
+      log(Level.Debug, msg, t = Option(tt.throwable(e)))
     }
 
   def debug[M](msg: => M, ctx: Map[String, String])(implicit render: Render[M], position: Position): F[Unit] =
@@ -86,7 +86,7 @@ abstract class DefaultLogger[F[_]](val minLevel: Level)(implicit clock: Clock[F]
       position: Position
   ): F[Unit] =
     F.whenA(minLevel <= Level.Debug) {
-      log(Level.Debug, msg, ctx, Some(tt.throwable(e)))
+      log(Level.Debug, msg, ctx, Option(tt.throwable(e)))
     }
 
   def info[M](msg: => M)(implicit render: Render[M], position: Position): F[Unit] =
@@ -96,7 +96,7 @@ abstract class DefaultLogger[F[_]](val minLevel: Level)(implicit clock: Clock[F]
 
   def info[M, E](msg: => M, e: E)(implicit render: Render[M], tt: ToThrowable[E], position: Position): F[Unit] =
     F.whenA(minLevel <= Level.Info) {
-      log(Level.Info, msg, t = Some(tt.throwable(e)))
+      log(Level.Info, msg, t = Option(tt.throwable(e)))
     }
 
   def info[M](msg: => M, ctx: Map[String, String])(implicit render: Render[M], position: Position): F[Unit] =
@@ -110,7 +110,7 @@ abstract class DefaultLogger[F[_]](val minLevel: Level)(implicit clock: Clock[F]
       position: Position
   ): F[Unit] =
     F.whenA(minLevel <= Level.Info) {
-      log(Level.Info, msg, ctx, Some(tt.throwable(e)))
+      log(Level.Info, msg, ctx, Option(tt.throwable(e)))
     }
 
   def warn[M](msg: => M)(implicit render: Render[M], position: Position): F[Unit] =
@@ -120,7 +120,7 @@ abstract class DefaultLogger[F[_]](val minLevel: Level)(implicit clock: Clock[F]
 
   def warn[M, E](msg: => M, e: E)(implicit render: Render[M], tt: ToThrowable[E], position: Position): F[Unit] =
     F.whenA(minLevel <= Level.Warn) {
-      log(Level.Warn, msg, t = Some(tt.throwable(e)))
+      log(Level.Warn, msg, t = Option(tt.throwable(e)))
     }
 
   def warn[M](msg: => M, ctx: Map[String, String])(implicit render: Render[M], position: Position): F[Unit] =
@@ -134,7 +134,7 @@ abstract class DefaultLogger[F[_]](val minLevel: Level)(implicit clock: Clock[F]
       position: Position
   ): F[Unit] =
     F.whenA(minLevel <= Level.Warn) {
-      log(Level.Warn, msg, ctx, Some(tt.throwable(e)))
+      log(Level.Warn, msg, ctx, Option(tt.throwable(e)))
     }
 
   def error[M](msg: => M)(implicit render: Render[M], position: Position): F[Unit] =
@@ -144,7 +144,7 @@ abstract class DefaultLogger[F[_]](val minLevel: Level)(implicit clock: Clock[F]
 
   def error[M, E](msg: => M, e: E)(implicit render: Render[M], tt: ToThrowable[E], position: Position): F[Unit] =
     F.whenA(minLevel <= Level.Error) {
-      log(Level.Error, msg, t = Some(tt.throwable(e)))
+      log(Level.Error, msg, t = Option(tt.throwable(e)))
     }
 
   def error[M](msg: => M, ctx: Map[String, String])(implicit render: Render[M], position: Position): F[Unit] =
@@ -158,6 +158,6 @@ abstract class DefaultLogger[F[_]](val minLevel: Level)(implicit clock: Clock[F]
       position: Position
   ): F[Unit] =
     F.whenA(minLevel <= Level.Error) {
-      log(Level.Error, msg, ctx, Some(tt.throwable(e)))
+      log(Level.Error, msg, ctx, Option(tt.throwable(e)))
     }
 }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.6.1
+sbt.version=1.7.2


### PR DESCRIPTION
When passing an exception to a log statement, it is not uncommon to pass in a `null` value, e.g., instead of 
```scala
logger.error("oh no")
```
sometimes 
```scala
logger.error("oh no", null)
```
is called. 

In the `DefaultLogger`, the passed `ToThrowable[E]` is turned into an `Option[Throwable]`.
In most Scala code the expectation is that for any `val t: Option[T]` either `t == None` or `t == Some(x)` for `x != null`. With this change we avoid creating a `Some(null)` value if the `cause` to be logged is `null`.