### PR TITLE
Get rid of the blocking call in OdinLoggerAdapter

### DIFF
--- a/slf4j/src/main/scala/io/odin/slf4j/OdinLoggerAdapter.scala
+++ b/slf4j/src/main/scala/io/odin/slf4j/OdinLoggerAdapter.scala
@@ -19,7 +19,7 @@ case class OdinLoggerAdapter[F[_]](loggerName: String, underlying: OdinLogger[F]
   override def getName: String = loggerName
 
   private def run(level: Level, msg: String, t: Option[Throwable] = None): Unit =
-    dispatcher.unsafeRunSync(for {
+    dispatcher.unsafeRunAndForget(for {
       timestamp <- F.realTime
       _ <- underlying.log(
         LoggerMessage(


### PR DESCRIPTION
This PR was created to replace dispatcher.unsafeRunAndSync with dispatcher.unsafeRunAndForget.

Such change is motivated by the fact that dispatcher.unsafeRunAndSync is a blocking call which starts fiber execution in IO thread pools and blocks the current thread until the end of execution.

Proof: https://github.com/typelevel/cats-effect/blob/a7ca501029413ec1d62c0b6ea41893043852ea75/std/jvm/src/main/scala/cats/effect/std/DispatcherPlatform.scala#L50

The current blocking method potentially can lead to thread starvation problems and is also theoretically slower than its asynchronous counterpart.

There are no changes in logger behaviour, namely:
 - no changes in timestamps - they are collected only when IO fiber starts execution, just as before;
 - no changes in thread names - they are collected from a thread that runs IO fiber instead of a thread that calls logger, just as before.